### PR TITLE
Adds "no opinion"

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
 
       <dl class="dl-horizontal space">
         <dt><button class="btn btn-default btn-xs">under consideration</button></dt><dd>Mozilla's position on this specification is being discussed.</dd>
+        <dt><button class="btn btn-default btn-xs">no opinion</button></dt><dd>Mozilla offers no opinions regarding this specification.</dd>
         <dt><button class="btn btn-info btn-xs">undecided</button></dt><dd>There is no Mozilla position on this specification yet; more information, experimentation or deployment experience might help.</dd>
         <dt><button class="btn btn-primary btn-xs">involved</button></dt><dd>Mozilla is one of the parties working on this specification.</dd>
         <dt><button class="btn btn-success btn-xs">important</button></dt><dd>This specification is important to Mozilla.</dd>


### PR DESCRIPTION
There has been at least one case when Mozilla has extensively reviewed, collaborated, and implemented a specification but has decided to offer no public opinion. It would be difficult to add this option later should that need arise again.