### PR TITLE
Mark as a pilot so that the pages can be made public for a first round of pilot/experimental use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## What is this Repository?
 
+**This is now a _pilot_ of a process to decide and document what it thinks about emerging technical specifications for the Web (see below).  We are currently trying this process on a small number of specifications, so we can see how it works and make adjustments as needed before putting it in wider use.**
+
 This repo is where [Mozilla](https://mozilla.org/) decides and documents what it thinks about
 emerging technical specifications for the Web. Typically they're draft documents in the
 [IETF](https://ietf.org/), [W3C](https://w3.org/) (including the [WICG](https://wicg.github.io/)),

--- a/index.html
+++ b/index.html
@@ -20,6 +20,12 @@
       <div class="jumbotron">
         <h1><img src="asset/Firefox.svg" height="75" alt="Firefox"> Public Spec Positions</h1>
 
+        <p class="alert-warning">This is now a <strong>pilot</strong> of a process to decide and document
+        what it thinks about emerging technical specifications for the Web (see below).
+        We are currently trying this process on a small number of specifications,
+        so we can see how it works and make adjustments as needed
+        before putting it in wider use.</strong></p>
+
         <p>This page tracks Mozilla's positions on open Web and Web-related specifications submitted to standards
         bodies like the <a href="https://www.ietf.org/">IETF</a>, <a href="https://w3.org/">W3C</a>,
         and <a href="https://tc39.github.io/">Ecma TC39</a>.</p>


### PR DESCRIPTION
This allows us to run a pilot of this process with the repository public, which I think I'd prefer to trying to run the pilot with the repository still access-controlled.