### PR TITLE
Replace the `participating` position with `important`, `worth prototyping`, and `non-harmful`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Implementation status (or even intention) isn't tracked here; see [Firefox Platf
 The currently possible positions are:
 
 - `under consideration` - Mozilla's position on this specification is being discussed.
-- `important` - This specification is important to Mozilla.
-- `worth prototyping` - Mozilla sees this specification as likely enough to be important that it is worth prototyping and iterating on.
-- `non-harmful` - Mozilla does not see this specification as harmful, but is not convinced that it is worth working on.
+- `important` - This specification is conceptually good and is important to Mozilla.
+- `worth prototyping` - Mozilla sees this specification as conceptually good, and worth prototyping, getting feedback on its value, and iterating.
+- `non-harmful` - Mozilla does not see this specification as harmful, but is not convinced that it is a good approach or worth working on.
 - `defer` - Mozilla does not intend to look at this specification at all in the near future.
 - `harmful` - Mozilla considers this specification to be harmful in its current state.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Implementation status (or even intention) isn't tracked here; see [Firefox Platf
 The currently possible positions are:
 
 - `under consideration` - Mozilla's position on this specification is being discussed.
-- `participating` - Mozilla is one of the parties working on this specification.
+- `important` - This specification is important to Mozilla.
+- `worth prototyping` - Mozilla sees this specification as likely enough to be important that it is worth prototyping and iterating on.
+- `non-harmful` - Mozilla does not see this specification as harmful, but is not convinced that it is worth working on.
 - `defer` - Mozilla does not intend to look at this specification at all in the near future.
 - `harmful` - Mozilla considers this specification to be harmful in its current state.
 

--- a/activities.json
+++ b/activities.json
@@ -3,7 +3,7 @@
     "ciuName": null, 
     "description": "This document describes a common data model and API for the Web of Things. The Web Thing Description provides a vocabulary for describing physical devices connected to the World Wide Web in a machine readable format with a default JSON encoding. The Web Thing REST API and Web Thing WebSocket API allow a web client to access the properties of devices, request the execution of actions and subscribe to events representing a change in state. Some basic Web Thing Types are provided and additional types can be defined using semantic extensions with JSON-LD. In addition to this specification there is a note on Web Thing API Protocol Bindings which proposes non-normative bindings of the Web Thing API to various existing IoT protocols. There is also a document describing Web of Things Integration Patterns which provides advice on different design patterns for integrating connected devices with the Web of Things, and where each pattern is most appropriate.", 
     "mozBugUrl": null, 
-    "mozPosition": "participating", 
+    "mozPosition": "worth prototyping", 
     "mozPositionDetail": null, 
     "mozPositionIssue": 44, 
     "org": "W3C", 

--- a/activities.py
+++ b/activities.py
@@ -62,7 +62,9 @@ class ActivitiesJson(object):
         ("mozPositionIssue", False, int),
         ("mozPosition", True, [
             "under consideration",
-            "participating",
+            "important",
+            "worth prototyping",
+            "non-harmful",
             "defer",
             "harmful"
         ]),

--- a/index.html
+++ b/index.html
@@ -69,8 +69,10 @@
       <p>The possible positions are:</p>
 
       <dl class="dl-horizontal space">
-        <dt><button class="btn btn-default btn-xs">under consideration</button></dt><dd>Mozilla's position on this specification is being discussed.</dd>
-        <dt><button class="btn btn-primary btn-xs">participating</button></dt><dd>Mozilla is one of the parties working on this specification.</dd>
+        <dt><button class="btn btn-dark btn-xs">under consideration</button></dt><dd>Mozilla's position on this specification is being discussed.</dd>
+        <dt><button class="btn btn-primary btn-xs">important</button></dt><dd>This specification is important to Mozilla.</dd>
+        <dt><button class="btn btn-success btn-xs">worth prototyping</button></dt><dd>Mozilla is one of the proponents of this specification.</dd>
+        <dt><button class="btn btn-default btn-xs">non-harmful</button></dt><dd>Mozilla does not see this specification as harmful, but is not convinced that it is worth working on.</dd>
         <dt><button class="btn btn-warning btn-xs">defer</button></dt><dd>Mozilla does not intend to look at this specification at all in the near future.</dd>
         <dt><button class="btn btn-danger btn-xs">harmful</button></dt><dd>Mozilla considers this specification to be harmful in its current state.</dd>
       </dl>
@@ -83,9 +85,10 @@
     <script>
     $(document).ready(function(){
         var status_styles = {
-          "under consideration": "default",
-          "participating": "primary",
-          // note: there's also a currently-unused "success" style
+          "under consideration": "dark",
+          "important": "primary",
+          "worth prototyping": "success",
+          "non-harmful": "default",
           "defer": "warning",
           "harmful": "danger"
         }

--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@
 
       <dl class="dl-horizontal space">
         <dt><button class="btn btn-dark btn-xs">under consideration</button></dt><dd>Mozilla's position on this specification is being discussed.</dd>
-        <dt><button class="btn btn-primary btn-xs">important</button></dt><dd>This specification is important to Mozilla.</dd>
-        <dt><button class="btn btn-success btn-xs">worth prototyping</button></dt><dd>Mozilla is one of the proponents of this specification.</dd>
-        <dt><button class="btn btn-default btn-xs">non-harmful</button></dt><dd>Mozilla does not see this specification as harmful, but is not convinced that it is worth working on.</dd>
+        <dt><button class="btn btn-primary btn-xs">important</button></dt><dd>This specification is conceptually good and is important to Mozilla.</dd>
+        <dt><button class="btn btn-success btn-xs">worth prototyping</button></dt><dd>Mozilla sees this specification as conceptually good, and worth prototyping, getting feedback on its value, and iterating.</dd>
+        <dt><button class="btn btn-default btn-xs">non-harmful</button></dt><dd>Mozilla does not see this specification as harmful, but is not convinced that it is a good approach or worth working on.</dd>
         <dt><button class="btn btn-warning btn-xs">defer</button></dt><dd>Mozilla does not intend to look at this specification at all in the near future.</dd>
         <dt><button class="btn btn-danger btn-xs">harmful</button></dt><dd>Mozilla considers this specification to be harmful in its current state.</dd>
       </dl>


### PR DESCRIPTION
Fixes #51.