### PR TITLE
Fix inconsistency (mozPositionDetail vs. mozPositionDetails) in field name

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,9 +180,9 @@
             out.push('<dt>Description</dt>' +
                      '<dd>' + d.description + '</dd>')
           }
-          if (d.mozPositionDetails && d.mozPositionDetails !== "") {
+          if (d.mozPositionDetail && d.mozPositionDetail !== "") {
             out.push('<dt>Mozilla\'s Position</dt>' +
-                     '<dd>' + d.mozPositionDetails + '</dd>')
+                     '<dd>' + d.mozPositionDetail + '</dd>')
           }
           if (out.length > 0) {
             return '<dl class="dl-horizontal">' + out.join("\n")+ '</dl>'


### PR DESCRIPTION
I went with the singular simply because it required fewer changes (and
also doesn't invalidate any outstanding PRs).

This causes the detail added in #53 to actually show up.