### PR TITLE
Fix: prevent scroll top on click details icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
                 "render": function (data, type, row) {
                   if ((row.description && row.description !== "") ||
                       (row.details && row.details !== "")) {
-                    return "<a href='#'><span class='glyphicon glyphicon-info-sign' aria-hidden='true'></span><span class='sr-only'>details</span></a>"
+                    return "<a href='javascript:void(0)'><span class='glyphicon glyphicon-info-sign' aria-hidden='true'></span><span class='sr-only'>details</span></a>"
                   } else {
                     return ""
                   }


### PR DESCRIPTION
Just fixes behavior of https://mozilla.github.io/standards-positions/

## Before
![before](https://user-images.githubusercontent.com/19714/37442776-859b3e8e-284b-11e8-93af-dab8a5b6a045.gif)

## After

![after](https://user-images.githubusercontent.com/19714/37442788-98eb3e12-284b-11e8-98aa-d479d9e94d21.gif)

📝 `event.preventDefault()` is even better.