### PR TITLE
Improve cleaning of whitespace when importing specs.

### DIFF
--- a/activities.py
+++ b/activities.py
@@ -289,7 +289,7 @@ class SpecParser(object):
         """
         Return a BeautifulSoup's tag contents as a string.
         """
-        return "".join(tag.stripped_strings).replace("\n", " ")
+        return re.sub("\n\s*", " ", "".join(tag.strings)).strip()
 
     @staticmethod
     def clean_url(url):
@@ -351,7 +351,7 @@ class W3CParser(SpecParser):
             data['title'] = spec.h1.string
         except AttributeError:
             try:
-                data['title'] = spec.title.string
+                data['title'] = self.clean_tag(spec.title)
             except AttributeError:
                 sys.stderr.write("* Can't find the specification's title.\n")
                 sys.exit(1)

--- a/activities.py
+++ b/activities.py
@@ -289,7 +289,7 @@ class SpecParser(object):
         """
         Return a BeautifulSoup's tag contents as a string.
         """
-        return re.sub("\n\s*", " ", "".join(tag.strings)).strip()
+        return re.sub("\n\s*", " ", tag.get_text()).strip()
 
     @staticmethod
     def clean_url(url):

--- a/activities.py
+++ b/activities.py
@@ -348,7 +348,7 @@ class W3CParser(SpecParser):
             data['url'] = self.clean_url(url_string)
         data['org'] = self.org
         try:
-            data['title'] = spec.h1.string
+            data['title'] = self.clean_tag(spec.h1)
         except AttributeError:
             try:
                 data['title'] = self.clean_tag(spec.title)


### PR DESCRIPTION
This makes three changes to the whitespace cleanup:
* use `tag.strings` instead of `tag.stripped_strings` (which had the starting/ending whitespace of each tag removed), since use of the latter tended to remove whitespace around inlines
* instead of just replacing newlines with spaces, replace a newline *and any whitespace following it, including other newlines* with a space
* Remove starting and ending whitespace from the final result.

It also applies the whitespace cleaning to the title (in addition to the abstract).