### PR TITLE
semantic elements, try 2 to workaround git

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -240,5 +240,16 @@
     "org": "IETF",
     "title": "Zstandard Compression and the application/zstd Media Type",
     "url": "https://tools.ietf.org/html/rfc8478"
+  },
+   {
+    "ciuName": null,
+    "description": "This draft defines additions to CSS Grid, primarily for the subgrid feature.",
+    "mozBugUrl": 1349043,
+    "mozPosition": "important",
+    "mozPositionDetail": "Subgrid adds a critical enhancement to CSS Grid, in particular for many CSS Grid use-cases that require alignment across nested semantic elements.",
+    "mozPositionIssue": 125,
+    "org": "W3C",
+    "title": "CSS Grid Layout Module Level 2",
+    "url": "https://drafts.csswg.org/css-grid-2/"
   }
 ]


### PR DESCRIPTION
Nested elements and thus subgrid are important for maintaining semantic markup, and this is commit try 2 because git (or maybe GitHub) is too dumb to handle a simple text block diff and instead claims "This branch has conflicts that must be resolved" https://github.com/mozilla/standards-positions/pull/114