### PR TITLE
Switch HTML Modules to use WHATWG org.

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -127,7 +127,7 @@
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
     "mozPositionIssue": 137,
-    "org": "W3C",
+    "org": "WHATWG",
     "title": "HTML Modules",
     "url": "https://github.com/w3c/webcomponents/blob/gh-pages/proposals/html-modules-explainer.md"
   },

--- a/activities.py
+++ b/activities.py
@@ -57,7 +57,7 @@ class ActivitiesJson(object):
         ("title", True, StringType),
         ("description", True, StringType),
         ("ciuName", False, StringType),
-        ("org", True, ["W3C", "IETF", "Ecma", "Other"]),
+        ("org", True, ["W3C", "IETF", "Ecma", "WHATWG", "Other"]),
         ("group", False, StringType),
         ("url", True, UrlType),
         ("mozBugUrl", False, UrlType),


### PR DESCRIPTION
This makes validate.py support the WHATWG org, which was already half-supported
due to the presence of asset/WHATWG.svg.

This is a followup to the review discussion in #140.