### PR TITLE
Make the JS icon show up for Ecma standards.

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,9 @@
                     if (data === "IETF") {
                       extension = ".gif"
                     }
+                    if (data === "Ecma") {
+                      data = "JS"
+                    }
                     return "<img src='asset/" + data + extension + "' height='18px' alt='" + data + "'>"
                   } else {
                     return ""

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                     if (data === "IETF") {
                       extension = ".gif"
                     }
-                    if (data === "Ecma") {
+                    else if (data === "Ecma") {
                       data = "JS"
                     }
                     return "<img src='asset/" + data + extension + "' height='18px' alt='" + data + "'>"

--- a/index.html
+++ b/index.html
@@ -132,11 +132,10 @@
                     var extension = ".svg"
                     if (data === "IETF") {
                       extension = ".gif"
-                    }
-                    else if (data === "Ecma") {
+                    } else if (data === "Ecma") {
                       data = "JS"
                     }
-                    return "<img src='asset/" + data + extension + "' height='18px' alt='" + data + "'>"
+                    return `<img src='asset/${data}${extension}' height='18px' alt='${data}'>`
                   } else {
                     return ""
                   }


### PR DESCRIPTION
We had the JS icon in `asset/` but it wasn't showing up after we added the first Ecma position in #189.  This makes it show up.