### PR TITLE
Add IDs to rows, add UI to expose them, and :target styles for the linked-to row.

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -30,7 +30,7 @@
     "mozPositionIssue": 65,
     "org": "Ecma",
     "title": "BigInt",
-    "url": "http://tc39.github.io/proposal-bigint"
+    "url": "https://tc39.github.io/proposal-bigint"
   },
   {
     "ciuName": null,
@@ -85,7 +85,7 @@
     "mozPositionIssue": 59,
     "org": "W3C",
     "title": "CSS Shadow Parts",
-    "url": "http://drafts.csswg.org/css-shadow-parts"
+    "url": "https://drafts.csswg.org/css-shadow-parts"
   },
   {
     "ciuName": null,
@@ -206,7 +206,7 @@
     "mozPositionIssue": 60,
     "org": "W3C",
     "title": "HTML Imports",
-    "url": "http://www.w3.org/TR/2016/WD-html-imports-20160225"
+    "url": "https://www.w3.org/TR/2016/WD-html-imports-20160225"
   },
   {
     "ciuName": null,

--- a/activities.json
+++ b/activities.json
@@ -2,6 +2,7 @@
   {
     "ciuName": null,
     "description": "This memo introduces an informational HTTP status code that can be used to convey hints that help a client make preparations for processing the final response.",
+    "id": "http-early-hints",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1407355",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "We believe that experimentation with the 103 response code is worthwhile, while at the same time noting that its primary benefit comes from using it with rel=preload, which Firefox does not yet implement. We do have some concerns about the lack of clear interaction with Fetch, which we hope will be specified before the mechanism is put into widespread use.",
@@ -13,6 +14,7 @@
   {
     "ciuName": null,
     "description": "This specification defines an API allowing web applications to set an application-wide badge, shown in an operating-system-specific place associated with the application (such as the shelf or home screen), for the purpose of notifying the user when the state of the application has changed (e.g., when new messages have arrived), without showing a more heavyweight notification.",
+    "id": "badging",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -24,6 +26,7 @@
   {
     "ciuName": null,
     "description": "This proposal adds arbitrary-precision integers to ECMAScript.",
+    "id": "bigint",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1366287",
     "mozPosition": "non-harmful",
     "mozPositionDetail": "Shipping in Firefox.",
@@ -35,6 +38,7 @@
   {
     "ciuName": null,
     "description": "This draft defines additions to CSS Grid, primarily for the subgrid feature.",
+    "id": "subgrid",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1349043",
     "mozPosition": "important",
     "mozPositionDetail": "Subgrid adds a critical enhancement to CSS Grid, in particular for many CSS Grid use-cases that require alignment across nested semantic elements.",
@@ -46,6 +50,7 @@
   {
     "ciuName": null,
     "description": "An API for allowing web developers to define their own layout modes with javascript.",
+    "id": "css-layout-api",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1302337",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification allows developing prototypes of new CSS layout systems and provides an escape hatch for developers when the existing systems aren't good enough for a particular piece of a web page.",
@@ -57,6 +62,7 @@
   {
     "ciuName": "css-paint-api",
     "description": "An API for allowing web developers to define a custom CSS <image> with javascript, which will respond to style and size changes.",
+    "id": "css-paint-api",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1302328",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification allows developing prototypes of new graphical CSS features and provides an escape hatch for developers when the existing features aren't good enough for a particular piece of a web page.",
@@ -68,6 +74,7 @@
   {
     "ciuName": null,
     "description": "This CSS module defines an API for registering new CSS properties. Properties registered using this API are provided with a parse syntax that defines a type, inheritance behaviour, and an initial value.",
+    "id": "css-properties-and-values-api",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1273706",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification makes it significantly easier to use CSS custom properties in ways that are more like regular CSS properties.",
@@ -79,6 +86,7 @@
   {
     "ciuName": null,
     "description": "This specification defines the ::part() and ::theme() pseudo-elements on shadow hosts, allowing shadow hosts to selectively expose chosen elements from their shadow tree to the outside page for styling purposes.",
+    "id": "css-shadow-parts",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -90,6 +98,7 @@
   {
     "ciuName": null,
     "description": "Converting CSSOM value strings into meaningfully typed JavaScript representations and back can incur a significant performance overhead. This specification exposes CSS values as typed JavaScript objects to facilitate their performant manipulation.",
+    "id": "css-typed-om",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1278697",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification provides an easier way to manipulate the CSS object model.",
@@ -101,6 +110,7 @@
   {
     "ciuName": null,
     "description": "This specification defines a HTTP/2 frame type to allow clients to inform the server of their cache's contents. Servers can then use this to inform their choices of what to push to clients.",
+    "id": "http-cache-digest",
     "mozBugUrl": null,
     "mozPosition": "non-harmful",
     "mozPositionDetail": "This is experimental technology that might improve the use of server push by giving servers information about what is cached. It is still unclear how much this might improve performance; more experimentation is likely necessary to prove this out.",
@@ -112,6 +122,7 @@
   {
     "ciuName": null,
     "description": "This document defines an imperative mechanism which allows web developers to instruct a user agent to clear a site's locally stored data related to a host.",
+    "id": "clear-site-data",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1268889",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This feature is useful for sites to be able to recover from mistakes in deployment of certain web technologies like Service Workers, and thus makes them more confident about deploying such technology.",
@@ -123,6 +134,7 @@
   {
     "ciuName": null,
     "description": "This draft defines additions to CSSOM to make CSSStyleSheet objects directly constructable, along with a way to use them in DocumentOrShadowRoots.",
+    "id": "construct-stylesheets",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -134,6 +146,7 @@
   {
     "ciuName": null,
     "description": "A way to create new HTML elements implemented through JavaScript.",
+    "id": "custom-elements",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "A welcome successor to XBL!",
@@ -145,6 +158,7 @@
   {
     "ciuName": null,
     "description": "This will allow custom elements to have \"default\" accessibility semantics, analogous to how built-in elements have \"implicit\" or \"native\" semantics.",
+    "id": "custom-elements-a11y",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This is an important addition to custom elements as otherwise they'd have to publicly expose their internals in order to get accessibility correct.",
@@ -156,6 +170,7 @@
   {
     "ciuName": null,
     "description": "This document defines a simple mechanism for encrypting the Server Name Indication for TLS 1.3.",
+    "id": "tls-esni",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1494901",
     "mozPosition": "important",
     "mozPositionDetail": "This feature enables encryption of the server name in connection attempts. It provides much-needed protection against attempts by network observers to see what people are doing. This work is complementary with efforts to encrypt DNS requests that we are also driving.",
@@ -167,6 +182,7 @@
   {
     "ciuName": null,
     "description": "This specification defines a mechanism that allows developers to selectively enable and disable use of various browser features and APIs.",
+    "id": "feature-policy",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390801",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "Mozilla's primary interest in this specification is in the delegation of permissions to third-party contexts, and in particular permissions that might require the user to make a choice. To that end we are willing to prototype and ship the allow attribute, but given this reduction in scope the remaining functionality needs to be reevaluated in terms of naming and applicability.",
@@ -178,6 +194,7 @@
   {
     "ciuName": null,
     "description": "This document defines a set of Fetch metadata request headers that aim to provide servers with enough information to make a priori decisions about whether or not to service a request based on the way it was made, and the context in which it will be used.",
+    "id": "fetch-metadata",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1508292",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This gives servers useful context about requests that can be used to mitigate various security issues. The existing setup for embed/object elements gave some tough design challenges for this feature that were satisfactorily resolved. (There's also a reasonable expectation to be able to simplify these elements going forward.)",
@@ -189,6 +206,7 @@
   {
     "ciuName": null,
     "description": "A proposal for using URL fragments with spaces in them to select a bit of text to highlight and scroll to",
+    "id": "fragmentation",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "We feel that some of the use cases this proposal addresses are very important to address, but worry about the lack of a clear processing model and about possible compat constraints that may need implementation experience to fully understand.  More details are in the position issue.  See also the position on Scroll to Text Fragment, which aims to address similar use cases.",
@@ -200,6 +218,7 @@
   {
     "ciuName": "imports",
     "description": "HTML Imports are a way to include and reuse HTML documents in other HTML documents.",
+    "id": "html-imports",
     "mozBugUrl": null,
     "mozPosition": "harmful",
     "mozPositionDetail": "Mozilla anticipated that JavaScript modules would change the landscape here and would rather invest in evolving that, e.g., through HTML Modules. Having a single mechanism to deal with dependencies rather than several, potentially conflicting systems, seems preferable.",
@@ -211,6 +230,7 @@
   {
     "ciuName": null,
     "description": "An extension of the ES6 Script Modules system to include HTML Modules. These will allow web developers to package and access declarative content from script in a way that allows for good componentization and reusability, and integrates well into the existing ES6 Modules infrastructure.",
+    "id": "html-modules",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -222,6 +242,7 @@
   {
     "ciuName": null,
     "description": "This document defines two independent HTTP Cache-Control extensions that allow control over the use of stale responses by caches. This document is not an Internet Standards Track specification; it is published for informational purposes.",
+    "id": "http-stale-controls",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": " The stale-while-revalidate cache control extension appears to provide improved user experience with no obvious drawbacks. We take no position on the other mechanisms in RFC 5861 at this time.",
@@ -233,6 +254,7 @@
   {
     "ciuName": "client-hints-dpr-width-viewport",
     "description": "An increasing diversity of Web-connected devices and software capabilities has created a need to deliver optimized content for each device. This specification defines an extensible and configurable set of HTTP request header fields, colloquially known as Client Hints, to address this. They are intended to be used as input to proactive content negotiation; just as the Accept header field allows user agents to indicate what formats they prefer, Client Hints allow user agents to indicate device and agent specific preferences.",
+    "id": "http-client-hints",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=935216",
     "mozPosition": "non-harmful",
     "mozPositionDetail": "Architecturally, Mozilla prefers client-side solutions for retrieving alternate versions of content, such as the HTML &lt;picture> tag. Despite these architectural preferences, we find that Client-Hints do not present a concrete harm to the web or to its users. ",
@@ -244,6 +266,7 @@
   {
     "ciuName": "loading-lazy-attr",
     "description": "Enabling images to be fetched at a later time, when the user is likely to look at them.",
+    "id": "loading-lazy-attr",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1542784",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "As currently scoped in the HTML pull request this is a reasonable addition to how images are fetched. (Note that the scope on Can I use is slightly bigger. Frames are likely a reasonable addition, but have their own set of design challenges.)",
@@ -255,6 +278,7 @@
   {
     "ciuName": null,
     "description": "This document updates RFC 6761 with the goal of ensuring that \"localhost\" can be safely relied upon as a name for the local host's loopback interface. To that end, stub resolvers are required to resolve localhost names to loopback addresses. Recursive DNS servers are required to return \"NXDOMAIN\" when queried for localhost names, making non-conformant stub resolvers more likely to fail and produce problem reports that result in updates. Together, these requirements would allow applications and specifications to join regular users in drawing the common-sense conclusions that \"localhost\" means \"localhost\", and doesn't resolve to somewhere else on the network.",
+    "id": "let-localhost-be-localhost",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1220810",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "The proposal, to the extent it applies to browsers, is to hardcode localhost to always resolve to a loopback address instead of invoking the resolver library to perform such translation. Since browsers (including Firefox) treat files hosted on localhost to be more privileged than remote content, this proposal seems to be a good belt-and-suspenders approach to prevent certain exploits.",
@@ -266,6 +290,7 @@
   {
     "ciuName": null,
     "description": "This document defines a web platform API that lets websites gain write access to the native file system. It builds on [FILE-API], but adds lots of new functionality on top.",
+    "id": "native-file-system",
     "mozBugUrl": null,
     "mozPosition": "defer",
     "mozPositionDetail": "The ability to read and write from the filesystem is potentially very dangerous. We will need to carefully consider any solution in light of the security and privacy implications. We recognize that the spec authors take this issue seriously, but we are concerned that any solution will increase the risk of security incidents more than we are willing to tolerate. Right now, there isn't enough detail in the specification to make an assessment of these risks, so we will defer our decision until we have more information.",
@@ -277,6 +302,7 @@
   {
     "ciuName": null,
     "description": "This specification defines a delivery mechanism for a number of policies which are to be applied to an entire origin. It compliments header-based delivery mechanisms for existing policies (Content Security Policy, Referrer Policy, etc).",
+    "id": "origin-policy",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1508290",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "Giving developers the ability to set policies for an entire origin is a powerful new primitive that will benefit security of applications as well as performance due to the ability to bypass CORS preflights. The renewed effort to make this happen takes a strong anti-tracking stance that is in line with our efforts around privacy in Fetch, such as isolating the HTTP cache. Given this, it seems worth figuring out if this can be made viable.",
@@ -288,6 +314,7 @@
   {
     "ciuName": null,
     "description": "This specification describes a method that enables web applications to synchronize data in the background.",
+    "id": "periodic-background-sync",
     "mozBugUrl": null,
     "mozPosition": "harmful",
     "mozPositionDetail": "We're concerned that this feature would allow users to be tracked across networks (leaking private information about location and IP address and how they change over time), and that it would allow script execution and resource consumption when it isn't clear to the user that they're interacting with the site.  We might reconsider this position given evidence that these concerns can be safely addressed, however, addressing them for periodic background sync appears substantially harder than doing so for one-off background sync.",
@@ -299,6 +326,7 @@
   {
     "ciuName": "permissions-api",
     "description": "The Permissions Standard defines common infrastructure for other specifications that need to interact with browser permissions. It also defines an API to allow web applications to query and request changes to the status of a given permission.",
+    "id": "permissions",
     "mozBugUrl": null,
     "mozPosition": "important",
     "mozPositionDetail": "Mozilla believes that the ability to work with user permissions is critical for user agency. There are certain aspects of the API that are not suitable for the permissions model used in Firefox and so we would like to work on improving several aspects of the API. In particular, we think that the way that status of permissions needs to more accurately reflect the different states that exist or could exist. We also think that the interactions with Feature Policy need to be better clarified. We're committed to fixing this, because permissions has become critical in making the web a more capable platform and it is important to ensure that we preserve user control over their online experience.",
@@ -310,6 +338,7 @@
   {
     "ciuName": null,
     "description": "This specification intends to provide APIs to allow websites to create a floating video window always on top of other windows so that users may continue consuming media while they interact with other content sites, or applications on their device.",
+    "id": "picture-in-picture",
     "mozBugUrl": null,
     "mozPosition": "defer",
     "mozPositionDetail": "We ship Picture-in-Picture (PiP) as a feature in Firefox, but without exposing a JavaScript API. We are evaluating if our PiP UI affordances are sufficient for users and web applications. In the future, we may reconsider exposing the API, which is why we have chosen to 'defer'.",
@@ -321,6 +350,7 @@
   {
     "ciuName": null,
     "description": "A proposal for extending URL fragment syntax with a list of text bits to highlight and scroll to",
+    "id": "scroll-to-text-fragment",
     "mozBugUrl": null,
     "mozPosition": "non-harmful",
     "mozPositionDetail": "We feel that some of the use cases this proposal addresses are very important to address, but that this specific proposal introduces various harmful aspects in the process of addressing them.  We feel that it would be worth prototyping a proposal with those harmful aspects removed.  More details are in the position issue.  See also the position on Fragmention, which aims to address similar use cases.",
@@ -332,6 +362,7 @@
   {
     "ciuName": null,
     "description": "A use of TLS Exported Authenticators is described which enables HTTP/2 clients and servers to offer additional certificate-based credentials after the connection is established. The means by which these credentials are used with requests is defined.",
+    "id": "http2-secondary-certs",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification enables client authentication in HTTP/2, which is of some benefit. However, it is the server authentication that is most interesting from a privacy perspective. There are some challenges that would need to be worked through before this could be deployed in anything other than an experiment.",
@@ -343,6 +374,7 @@
   {
     "ciuName": null,
     "description": "This document specifies the \"SVCB\" and \"HTTPSSVC\" DNS resource record types to facilitate the lookup of information needed to make connections for origin resources, such as for HTTPS URLs. SVCB records allow an origin to be served from multiple network locations, each with associated parameters (such as transport protocol configuration and keying material for encrypting TLS SNI). They also enable aliasing of apex domains, which is not possible with CNAME. The HTTPSSVC DNS RR is a variation of SVCB for HTTPS and HTTP origins. By providing more information to the client before it attempts to establish a connection, these records offer potential benefits to both performance and privacy.",
+    "id": "dnsop-svcb-httpssvc",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "While there are some details of the proposal that may require refining, we beleive that this is a promising approach to support Encrypted SNI, and may help improve user experience with HTTP/3.",
@@ -354,6 +386,7 @@
   {
     "ciuName": null,
     "description": "A way to give a node in the DOM a hidden subtree in which the children of the node can be inserted.",
+    "id": "shadow-trees",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "A welcome successor to XBL!",
@@ -365,6 +398,7 @@
   {
     "ciuName": null,
     "description": "This document specifies how a server can send an HTTP request/ response pair, known as an exchange, with signatures that vouch for that exchange's authenticity. These signatures can be verified against an origin's certificate to establish that the exchange is authoritative for an origin even if it was transferred over a connection that isn't. The signatures can also be used in other ways described in the appendices. These signatures contain countermeasures against downgrade and protocol-confusion attacks.",
+    "id": "http-origin-signed-responses",
     "mozBugUrl": null,
     "mozPosition": "harmful",
     "mozPositionDetail": "Mozilla has concerns about the shift in the web security model required for handling web-packaged information. Specifically, the ability for an origin to act on behalf of another without a client ever contacting the authoritative server is worrisome, as is the removal of a guarantee of confidentiality from the web security model (the host serving the web package has access to plain text). We recognise that the use cases satisfied by web packaging are useful, and would be likely to support an approach that enabled such use cases so long as the foregoing concerns could be addressed.",
@@ -376,6 +410,7 @@
   {
     "ciuName": "streams",
     "description": "This specification provides APIs for creating, composing, and consuming streams of data that map efficiently to low-level I/O primitives.",
+    "id": "streams",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1128959",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "Streams are an important building block for many APIs, in particular around networking and media.",
@@ -387,6 +422,7 @@
   {
     "ciuName": null,
     "description": "Serializing and deserializing JavaScript Error objects.",
+    "id": "errors-structured-cloning",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1556604",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "Good extension to the object serialization algorithm (StructuredSerializeInternal) as currently there is no way to serialize errors.",
@@ -398,6 +434,7 @@
   {
     "ciuName": null,
     "description": "The WebTransport Protocol Framework enables clients constrained by the Web security model to communicate with a remote server using a secure multiplexed transport. It consists of a set of individual protocols that are safe to expose to untrusted applications, combined with a model that allows them to be used interchangeably. This document defines the overall requirements on the protocols used in WebTransport, as well as the common features of the protocols, support for some of which may be optional.",
+    "id": "webtransport",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "We are generally in support of a mechanism that addresses the use cases implied by this solution document. While major questions remain open at this time -- notably, multiplexing, the API surface, and available statistics -- we think that prototyping the proposed solution as details become more firm would be worthwhile. We would like see the new WebSocketStream and WebTransport stream APIs to be developed in concert with each other, so as to share as much design as possible.",
@@ -409,6 +446,7 @@
   {
     "ciuName": null,
     "description": "In Transport Layer Security (TLS) handshakes, certificate chains often take up the majority of the bytes transmitted. This document describes how certificate chains can be compressed to reduce the amount of data transmitted and avoid some round trips.",
+    "id": "tls-certificate-compression",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "Compression of certificates should provide some performance advantages.",
@@ -420,6 +458,7 @@
   {
     "ciuName": null,
     "description": "The QID Emoji Tag Sequences (or QID emoji, for short) have been proposed to provide a well-defined mechanism for implementations to support additional valid emoji that are not representable by Unicode characters or emoji zwj sequences. This mechanism allows for the interchange of emoji whose meaning is discoverable, and which should be correctly parsed by all conformant implementations (although only displayed by implementations that support it). The meaning of each of these valid emoji is established by reference to a Wikidata QID.",
+    "id": "unicode-emoji-qid",
     "mozBugUrl": null,
     "mozPosition": "under consideration",
     "mozPositionDetail": null,
@@ -431,6 +470,7 @@
   {
     "ciuName": null,
     "description": "This document defines a set of Client Hints that aim to provide developers with the ability to perform agent-based content negotiation when necessary, while avoiding the historical baggage and passive fingerprinting surface exposed by the venerable \"User-Agent\" header.",
+    "id": "ua-client-hints",
     "mozBugUrl": null,
     "mozPosition": "non-harmful",
     "mozPositionDetail": "Using Client Hints to deliver info derived from the User Agent header field for servers that specifically request this information may reduce the number of parties that can use this information for passively fingerprinting users. However, we could reduce this even further by freezing the User Agent string and requiring resources to actively request this information via the proposed NavigatorUAData interface JS APIs. This would also allow us to audit the callers. At this time, freezing the User Agent string without any client hints (which is not this proposal)seems worth-prototyping. We look forward to learning from other vendors who implement the \"GREASE-like UA Strings\" proposal and its effects on site compatibility.",
@@ -442,6 +482,7 @@
   {
     "ciuName": "webauthn",
     "description": "This specification defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more public key credentials, each scoped to a given WebAuthn Relying Party, are created by and bound to authenticators as requested by the web application. The user agent mediates access to authenticators and their public key credentials in order to preserve user privacy. Authenticators are responsible for ensuring that no operation is performed without user consent. Authenticators provide cryptographic proof of their properties to Relying Parties via attestation. This specification also describes the functional model for WebAuthn conformant authenticators, including their signature and attestation functionality.",
+    "id": "webauthn",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1294514",
     "mozPosition": "important",
     "mozPositionDetail": "Public key cryptographic authentication is a major improvement in the fight against phishing, and we encourage all security-conscious web applications to implement authentication flows utilizing Web Authentication in the future.",
@@ -453,6 +494,7 @@
   {
     "ciuName": "background-sync",
     "description": "This specification describes a method that enables web applications to synchronize data in the background.",
+    "id": "background-sync",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1547906",
     "mozPosition": "harmful",
     "mozPositionDetail": "We're concerned that this feature would allow users to be tracked across networks (leaking private information about location and IP address and how they change over time), and that it would allow script execution and resource consumption when it isn't clear to the user that they're interacting with the site.  We might reconsider this position given evidence that these concerns can be safely addressed.",
@@ -464,6 +506,7 @@
   {
     "ciuName": null,
     "description": "This specification describes an API that can be used to retrieve the amount of budget an origin has available for resource consuming background operations, as well as the cost associated with doing such an operation.",
+    "id": "budget-api",
     "mozBugUrl": null,
     "mozPosition": "non-harmful",
     "mozPositionDetail": "This specification is being abandoned.",
@@ -475,6 +518,7 @@
   {
     "ciuName": "midi",
     "description": "This specification defines an API supporting the MIDI (Musical Instrument Digital Interface) protocol, enabling web applications to enumerate and select MIDI input and output devices on the client system and send and receive MIDI messages. It is intended to enable non-music MIDI applications as well as music ones, by providing low-level access to the MIDI devices available on the users' systems.",
+    "id": "webmidi",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=836897",
     "mozPosition": "under consideration",
     "mozPositionDetail": null,
@@ -486,6 +530,7 @@
   {
     "ciuName": "web-share",
     "description": "This specification defines an API for sharing text, links and other content to an arbitrary destination of the user's choice.The available share targets are not specified here; they are provided by the user agent. They could, for example, be apps, websites or contacts.",
+    "id": "web-share",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1312422",
     "mozPosition": "under consideration",
     "mozPositionDetail": null,
@@ -497,6 +542,7 @@
   {
     "ciuName": null,
     "description": "This specification defines an API that allows websites to declare themselves asweb share targets, which can receive shared content from either the Web Share API, or system events (e.g., shares from native apps).This is a similar mechanism to navigator.registerProtocolHandler, in that it works by registering the website with the user agent, to later be invoked from another site or native application via the user agent (possibly at the discretion of the user). The difference is that registerProtocolHandler registers the handler via a programmatic API, whereas a Web Share Target is declared in the Web App Manifest, to be registered at a time of the user agent or user's choosing.",
+    "id": "web-share-target",
     "mozBugUrl": null,
     "mozPosition": "under consideration",
     "mozPositionDetail": null,
@@ -508,6 +554,7 @@
   {
     "ciuName": null,
     "description": "This document describes a common data model and API for the Web of Things. The Web Thing Description provides a vocabulary for describing physical devices connected to the World Wide Web in a machine readable format with a default JSON encoding. The Web Thing REST API and Web Thing WebSocket API allow a web client to access the properties of devices, request the execution of actions and subscribe to events representing a change in state. Some basic Web Thing Types are provided and additional types can be defined using semantic extensions with JSON-LD. In addition to this specification there is a note on Web Thing API Protocol Bindings which proposes non-normative bindings of the Web Thing API to various existing IoT protocols. There is also a document describing Web of Things Integration Patterns which provides advice on different design patterns for integrating connected devices with the Web of Things, and where each pattern is most appropriate.",
+    "id": "web-thing-api",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -519,6 +566,7 @@
   {
     "ciuName": "webusb",
     "description": "This document describes an API for securely providing access to Universal Serial Bus devices from web pages.",
+    "id": "webusb",
     "mozBugUrl": null,
     "mozPosition": "harmful",
     "mozPositionDetail": "Because many USB devices are not designed to handle potentially-malicious interactions over the USB protocols and because those devices can have significant effects on the computer they're connected to, we believe that the security risks of exposing USB devices to the Web are too broad to risk exposing users to them or to explain properly to end users to obtain meaningful informed consent. It also poses risks that sites could use USB device identity or data stored on USB devices as tracking identifiers.",
@@ -530,6 +578,7 @@
   {
     "ciuName": null,
     "description": "This specification defines an API for running scripts in stages of the rendering pipeline independent of the main javascript execution environment.",
+    "id": "worklets",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1315239",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This specification is essential for allowing features like the CSS Paint API and CSS Layout API to be implemented in a safe way.",
@@ -541,6 +590,7 @@
   {
     "ciuName": null,
     "description": "Zstandard, or \"zstd\" (pronounced \"zee standard\"), is a data compression mechanism. This document describes the mechanism and registers a media type and content encoding to be used when transporting zstd-compressed content via Multipurpose Internet Mail Extensions (MIME). Despite use of the word \"standard\" as part of its name, readers are advised that this document is not an Internet Standards Track specification; it is being published for informational purposes only.",
+    "id": "zstd",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1301878",
     "mozPosition": "defer",
     "mozPositionDetail": "While we believe zstd is a promising technology, its use in a general-purpose web browser (given the existing slate of compression algorithms) has not been demonstrated to provide compelling new utility, and does not clearly warrant the additional maintenance cost and attack surface of adding such code. We are deferring a final position pending a more comprehensive and quantitative analysis of the benefits zstd would unlock on the web today - either dictionary-less, with static dictionaries, or with dynamic dictionaries. For either of the latter two options, we'd also need a credible plan for generating and delivering those dictionaries that aligns with our values.",
@@ -552,6 +602,7 @@
   {
     "ciuName": null,
     "description": "The enterkeyhint attribute specifies what action label (or icon) to present for the enter key on virtual keyboards.",
+    "id": "enterkeyhint-attr",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490661",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": null,
@@ -563,6 +614,7 @@
   {
     "ciuName": null,
     "description": "The template element is used to declare fragments of HTML that can be cloned and inserted in the document by script.",
+    "id": "template-element",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "A reasonable addition to HTML (and XML), if not somewhat taxing on the parser.",

--- a/activities.py
+++ b/activities.py
@@ -146,6 +146,11 @@ class ActivitiesJson(object):
                 errors.append("Entry %i is not a dictionary." % i)
             title = entry.get("title", "entry %i" % i)
             errors = errors + self.validate_entry(entry, title)
+            # This is *outside* validate_entry so that "add" can add an
+            # entry with an empty ID (which must then be filled in), but
+            # it will cause a validation error for other operations.
+            if entry.get("id", "") == "":
+                errors.append("{} includes has empty id".format(title))
         return errors
 
     def validate_entry(self, entry, title=None):

--- a/activities.py
+++ b/activities.py
@@ -57,7 +57,7 @@ class ActivitiesJson(object):
     """
 
     expected_entry_items = [  # (name, required?, type)
-        ("cui_name", False, StringType),
+        ("id", True, StringType),
         ("title", True, StringType),
         ("description", True, StringType),
         ("ciuName", False, StringType),
@@ -121,10 +121,14 @@ class ActivitiesJson(object):
             e["title"].lower().strip() for e in self.data
         ]:
             raise ValueError(
-                ["%s already contains %s" % (self.filename, entry["title"])]
+                ["%s already contains title %s" % (self.filename, entry["title"])]
+            )
+        if entry["id"] in [e["id"] for e in self.data]:
+            raise ValueError(
+                ["%s already contains id %s" % (self.filename, entry["id"])]
             )
         if entry["url"] in [e["url"] for e in self.data]:
-            raise ValueError(["%s already contains %s" % (self.filename, entry["url"])])
+            raise ValueError(["%s already contains url %s" % (self.filename, entry["url"])])
 
     def validate(self):
         """
@@ -198,6 +202,7 @@ class SpecEntry(object):
     def __init__(self, spec_url):
         self.orig_url = spec_url
         self.data = {
+            "id": u"",
             "title": None,
             "description": None,
             "ciuName": None,

--- a/index.html
+++ b/index.html
@@ -29,6 +29,15 @@
       .space dt {
         padding-bottom: 5px;
       }
+
+      table.dataTable > tbody > tr:target,
+      table.dataTable > tbody > tr.shown:target + tr {
+        background: #fd0;
+      }
+
+      tr:not(:hover):not(:focus-within) > .link-control > a {
+        visibility: hidden;
+      }
     </style>
   </head>
   <body>
@@ -62,6 +71,7 @@
         <table id="mozPositions" class="table table-hover dataTable">
           <thead>
             <tr>
+              <th></th>
               <th></th>
               <th class="sorting">Specification</th>
               <th class="sorting">Mozilla Position</th>
@@ -120,8 +130,23 @@
               dataSrc: ''
           },
           dom: 'ilfrtip',
-          "order": [[2, "asc"]],
+          rowId: 'id',
+          "order": [[3, "asc"]],
           "columns": [
+              {
+                "className": 'link-control',
+                "data": null,
+                "defaultContent": '',
+                "render": function (data, type, row) {
+                  var id = data.id;
+                  if (id != "") {
+                    return "<a href='#" + id + "'><span class='glyphicon glyphicon-link' aria-hidden='true'></span><span class='sr-only'>link</span></a>";
+                  }
+                  return "";
+                },
+                "orderable": false,
+                "searchable": false
+              },
               {
                 "data": "org",
                 "render": function (data, type, row) {

--- a/index.html
+++ b/index.html
@@ -243,7 +243,16 @@
         }
 
         // Add event listener for opening and closing details
-        $('#mozPositions').find('tbody').on('click', 'td', function () {
+        $('#mozPositions').find('tbody').on('click', 'td', function (event) {
+          var a = $(event.target).closest('a');
+          if (a.length > 0 && !a[0].parentNode.classList.contains("details-control")) {
+            // Do nothing if the click was on a link, except for the
+            // details-control.
+            // FIXME: This is really a bad way to handle the
+            // details-control link!
+            return;
+          }
+
           var tr = $(this).closest('tr');
           var row = ptable.row( tr );
           if ( row.child.isShown() ) {

--- a/index.html
+++ b/index.html
@@ -107,6 +107,8 @@
     <script src="components/datatables-plugins/sorting/enum.js"></script>
     <script src="components/bootstrap/dist/js/bootstrap.min.js"></script>
     <script>
+    var gFirstTableRender = true;
+
     $(document).ready(function(){
         var status_styles = {
           "under consideration": "dark",
@@ -267,6 +269,23 @@
               row.child( format(row.data()) ).show();
               tr.addClass('shown');
             }
+          }
+        } );
+
+        // Work around bugs in both Chrome and Firefox relating to
+        // anchor scrolling and :target selection.
+        $('#mozPositions').on('order.dt', function() {
+          if (gFirstTableRender) {
+            gFirstTableRender = false;
+            setTimeout(function() {
+              var hash = location.hash;
+              if (hash != "") {
+                // just "location.hash = location.hash" would be enough for
+                // Firefox, but not Chrome.
+                location.hash = "";
+                location.hash = hash;
+              }
+            }, 0);
           }
         } );
     })


### PR DESCRIPTION
This adds IDs to rows, add UI to expose them, and :target styles for the linked-to row.

Fixes #245.

This is mostly done, but not quite ready yet.  I need to look into browser bugs with both anchor-scrolling and `:target` when the content is generated dynamically -- I think it's probably stuff that ought to work but doesn't.  But maybe I'm doing something wrong.