### PR TITLE
Mark RFC 5861 as "Proposal"

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -293,9 +293,9 @@
     "id": "http-stale-controls",
     "mozBugUrl": null,
     "mozPosition": "worth prototyping",
-    "mozPositionDetail": " The stale-while-revalidate cache control extension appears to provide improved user experience with no obvious drawbacks. We take no position on the other mechanisms in RFC 5861 at this time.",
+    "mozPositionDetail": "The stale-while-revalidate cache control extension appears to provide improved user experience with no obvious drawbacks. We take no position on the other mechanisms in RFC 5861 at this time.",
     "mozPositionIssue": 144,
-    "org": "IETF",
+    "org": "Proposal",
     "title": "HTTP Cache-Control Extensions for Stale Content",
     "url": "https://tools.ietf.org/html/rfc5861"
   },


### PR DESCRIPTION
This is not an IETF product.

I checked the other RFCs listed and the others are IETF products. Though neither is "Standards Track", they at least have consensus to publish.  Formally, this document is just random stuff Mark thought up.  Personally, I think that it would be fine to move `stale-while-revalidate` to the IETF proper, but that's not necessarily work with a large pay-off.