### PR TITLE
Center the organization logos.

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
                 "searchable": false
               },
               {
+                "className": "dt-body-center",
                 "data": "org",
                 "render": function (data, type, row) {
                   if (type !== "display") {


### PR DESCRIPTION
This is a followup to #284 and #286, which made wider use of a narrower organization icon for proposals.

I think the resulting table looks better when that column is centered.