### PR TITLE
Check the correct property name when determining whether to add details icon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
                 "defaultContent": '',
                 "render": function (data, type, row) {
                   if ((row.description && row.description !== "") ||
-                      (row.details && row.details !== "")) {
+                      (row.mozPositionDetail && row.mozPositionDetail !== "")) {
                     return iconLink(null, 'details', 'info-sign');
                   } else {
                     return ""


### PR DESCRIPTION
This fixes the missing details icon for "ARIA Annotations", which lacks
a description but does have a mozPositionDetail.  There is no details
property anywhere.

This error seems to date back to the original commit.