### PR TITLE
Return to canonical format by running `activities.py sort`.

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -339,7 +339,10 @@
     "ciuName": null,
     "description": "An API to enable objects other than built-in form control elements to participate in form submission, form validation, and so on.",
     "id": "form-participation-api",
-    "mozBugUrl": [ "https://bugzilla.mozilla.org/show_bug.cgi?id=1518442", "https://bugzilla.mozilla.org/show_bug.cgi?id=1552327" ],
+    "mozBugUrl": [
+      "https://bugzilla.mozilla.org/show_bug.cgi?id=1518442",
+      "https://bugzilla.mozilla.org/show_bug.cgi?id=1552327"
+    ],
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "These propose what seems likely to be a useful addition to allow custom controls to participate in form validation and submission.",
     "mozPositionIssue": 150,


### PR DESCRIPTION
Followup to #315.