### PR TITLE
Stop removing trailing slashes from URLs, to save redirects.

### DIFF
--- a/activities.py
+++ b/activities.py
@@ -357,8 +357,7 @@ class SpecParser(object):
         Canonicalise a URL.
         """
         link = urlsplit(url)
-        path = link.path
-        return "%s://%s%s" % (link.scheme, link.netloc.lower(), path)
+        return "%s://%s%s" % (link.scheme, link.netloc.lower(), link.path)
 
     def parse(self, spec, url_string):
         """

--- a/activities.py
+++ b/activities.py
@@ -358,8 +358,6 @@ class SpecParser(object):
         """
         link = urlsplit(url)
         path = link.path
-        if path[-1] == "/":
-            path = path[:-1]
         return "%s://%s%s" % (link.scheme, link.netloc.lower(), path)
 
     def parse(self, spec, url_string):


### PR DESCRIPTION
To match the change in #319, we should stop removing the trailing
slashes from URLs; those URLs will generally redirect to re-add the
trailing slash.