### PR TITLE
Add Import Attributes (worth prototyping)

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -508,6 +508,18 @@
   },
   {
     "ciuName": null,
+    "description": "The ES Import Attributes and JSON modules proposal adds an inline syntax for module import statements to pass on more information alongside the module specifier, and an initial application for such attributes in supporting JSON modules in a common way across JavaScript environments.",
+    "id": "import-attributes",
+    "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1648614",
+    "mozPosition": "worth prototyping",
+    "mozPositionDetail": "This proposal enables the importing of JSON content into a JS module. This mechanism is a prerequisite for HTML/CSS/JSON modules.",
+    "mozPositionIssue": 373,
+    "org": "Ecma",
+    "title": "Import Attributes",
+    "url": "https://tc39.es/proposal-import-attributes/"
+  },
+  {
+    "ciuName": null,
     "description": "This document proposes a few changes to cookies inspired by the properties of the HTTP State Tokens mechanism.  First, cookies should be treated as \"SameSite=Lax\" by default.  Second, cookies that explicitly assert \"SameSite=None\" in order to enable cross-site delivery should also be marked as \"Secure\".  Third, same-site should take the scheme of the sites into account.  Fourth, cookies should respect schemes.  Fifth, cookies associated with non-secure schemes should be removed at the end of a user's session.  Sixth, the definition of a session should be tightened.",
     "id": "cookie-incrementalism",
     "mozBugUrl": null,


### PR DESCRIPTION
closes #373

I was getting an error when running activities.py -- `ERROR: Can't figure out what organisation github.com belongs to!` but we already have a TC39 proposal here. Would it make sense to patch activities.py or should we just do this manually?