### PR TITLE
rename import attributes to import conditions

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -521,7 +521,7 @@
   {
     "ciuName": null,
     "description": "The Import Conditions and JSON modules proposal adds an inline syntax for module import statements to pass on more information alongside the module specifier, and an initial application for such attributes in supporting JSON modules in a common way across JavaScript environments.",
-    "id": "import-conditions",
+    "id": "import-attributes",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1648614",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This proposal enables the importing of JSON content into a JS module. This mechanism is a prerequisite for HTML/CSS/JSON modules.",

--- a/activities.json
+++ b/activities.json
@@ -520,15 +520,15 @@
   },
   {
     "ciuName": null,
-    "description": "The ES Import Attributes and JSON modules proposal adds an inline syntax for module import statements to pass on more information alongside the module specifier, and an initial application for such attributes in supporting JSON modules in a common way across JavaScript environments.",
-    "id": "import-attributes",
+    "description": "The Import Conditions and JSON modules proposal adds an inline syntax for module import statements to pass on more information alongside the module specifier, and an initial application for such attributes in supporting JSON modules in a common way across JavaScript environments.",
+    "id": "import-conditions",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1648614",
     "mozPosition": "worth prototyping",
     "mozPositionDetail": "This proposal enables the importing of JSON content into a JS module. This mechanism is a prerequisite for HTML/CSS/JSON modules.",
     "mozPositionIssue": 373,
     "org": "Ecma",
-    "title": "Import Attributes",
-    "url": "https://tc39.es/proposal-import-attributes/"
+    "title": "Import Conditions",
+    "url": "https://tc39.es/proposal-import-conditions/"
   },
   {
     "ciuName": null,


### PR DESCRIPTION
The proposal was renamed to import-conditions, I don't know if it's supposed to be edited here.