### PR TITLE
Replace UTF quote with \u2019 per "./activities.py sort"

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1488,7 +1488,7 @@
     "mdnUrl": null,
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1690255",
     "mozPosition": "worth prototyping",
-    "mozPositionDetail": "Automation is an important capability for the web platform - for example, reliable automated testing makes it easier for websites to offer a functional user experience. The current standard protocol for building these tools has fallen behind demonstrated needs, which has in part led to new tools being built on Chrome DevTools Protocol. This makes it harder to automate across multiple browsers and versions of browsers - it’d be better for the standard protocol to support these needs.",
+    "mozPositionDetail": "Automation is an important capability for the web platform - for example, reliable automated testing makes it easier for websites to offer a functional user experience. The current standard protocol for building these tools has fallen behind demonstrated needs, which has in part led to new tools being built on Chrome DevTools Protocol. This makes it harder to automate across multiple browsers and versions of browsers - it\u2019d be better for the standard protocol to support these needs.",
     "mozPositionIssue": 632,
     "org": "W3C",
     "title": "WebDriver BiDi",


### PR DESCRIPTION
If you run "./activities.py sort" on the repo before this patch (to "Validate activities.json and write it out again in the canonical sorted order"), you get one change, which is precisely the change I'm making here: replacing a fancy UTF single-quote character with its encoded version, `\u2019`.

It seems we have several other such `\u2019` tokens already in this file, so I assume that representation is acceptable. So, this patch makes this replacement, so that `./activities.py sort` becomes a no-op.