### PR TITLE
distinguish standards-track drafts vs proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ emerging technical specifications for the Web. Typically such specs are standard
 [WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39).
 We may also provide positions on documents located outside a standards process, 
 e.g. those in W3C Community Groups such as [WICG](https://wicg.github.io/) 
-or other community incubation efforts with well-understood IPR terms, 
+or other community incubation efforts with well-understood
+<abbr title="intellectual property rights">IPR</abbr> terms, 
 but as a general rule believe that any such work must be moved to a formal standards track 
 before it’s appropriate for adoption as part of the web platform.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ _See [the dashboard](https://mozilla.github.io/standards-positions/) for Mozilla
 ## What is this Repository?
 
 This repo is where [Mozilla](https://mozilla.org/) decides and documents what it thinks about
-emerging technical specifications for the Web. Typically they're standards-track drafts in the
+emerging technical specifications for the Web. Typically such specs are standards-track drafts in the
 [IETF](https://ietf.org/), [W3C](https://w3.org/),
-[WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39), 
-but they could come from elsewhere such as proposals 
-from W3C Community Groups (like [WICG](https://wicg.github.io/)) 
-or other community incubation efforts with well-understood IPR terms.
+[WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39).
+We may also provide positions on documents located outside a standards process, 
+e.g. those in W3C Community Groups such as [WICG](https://wicg.github.io/) 
+or other community incubation efforts with well-understood IPR terms, 
+but as a general rule believe that any such work must be moved to a formal standards track 
+before it’s appropriate for adoption as part of the web platform.
 
 Having a clear Mozilla position on these specifications helps us align our thinking and communicate
 it clearly to these standards bodies, as well as other browsers.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ emerging technical specifications for the Web. Typically such specs are standard
 [IETF](https://ietf.org/), [W3C](https://w3.org/),
 [WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39).
 We may also provide positions on documents located outside a standards process, 
-e.g. those in W3C Community Groups such as [WICG](https://wicg.github.io/) 
+e.g., those in W3C Community Groups such as [WICG](https://wicg.github.io/) 
 or other community incubation efforts with well-understood
 <abbr title="intellectual property rights">IPR</abbr> terms, 
 but as a general rule believe that any such work must be moved to a formal standards track 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ _See [the dashboard](https://mozilla.github.io/standards-positions/) for Mozilla
 ## What is this Repository?
 
 This repo is where [Mozilla](https://mozilla.org/) decides and documents what it thinks about
-emerging technical specifications for the Web. Typically they're draft documents in the
-[IETF](https://ietf.org/), [W3C](https://w3.org/) (including the [WICG](https://wicg.github.io/)),
-[WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39), but they could come from
-elsewhere too.
+emerging technical specifications for the Web. Typically they're standards-track drafts in the
+[IETF](https://ietf.org/), [W3C](https://w3.org/),
+[WHATWG](https://whatwg.org/), and [Ecma TC39](https://github.com/tc39), 
+but they could come from elsewhere such as proposals 
+from W3C Community Groups (like [WICG](https://wicg.github.io/)) 
+or other community incubation efforts with well-understood IPR terms.
 
 Having a clear Mozilla position on these specifications helps us align our thinking and communicate
 it clearly to these standards bodies, as well as other browsers.


### PR DESCRIPTION
distinguish standards-track drafts vs proposals right up front to help reduce confusion that WICG (or any CG) is standards-track (or in any way produces "standards")