### PR TITLE
Add position for WebMIDI (Add-On Gated)

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1477,7 +1477,7 @@
     "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=836897",
     "mozPosition": "positive",
-    "mozPositionDetail": "This specification is a reasonable technical design for exposing MIDI devices to JavaScript, which has some demonstrated use-cases in the market. MIDI devices are not universally hardened against adversarial input (especially when sysex is involved) so we don't believe this API is safe to expose in the casual and low-trust context of ordinary websites. We therefore only expose it in Firefox if the user has installed a site-specific add-on to explicitly extend the base web platform with high-trust capabilities ordinarily reserved for installed software.”,
+    "mozPositionDetail": "This specification is a reasonable technical design for exposing MIDI devices to JavaScript, which has some demonstrated use-cases in the market. MIDI devices are not universally hardened against adversarial input (especially when sysex is involved) so we don't believe this API is safe to expose in the casual and low-trust context of ordinary websites. We therefore only expose it in Firefox if the user has installed a site-specific add-on to explicitly extend the base web platform with high-trust capabilities ordinarily reserved for installed software.",
     "mozPositionIssue": 58,
     "org": "W3C",
     "title": "Web MIDI API (Add-On Gated)",

--- a/activities.json
+++ b/activities.json
@@ -1477,7 +1477,7 @@
     "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=836897",
     "mozPosition": "positive",
-    "mozPositionDetail": "This specification is a reasonable technical design for exposing MIDI devices to JavaScript, which has some demonstrated use-cases in the market. MIDI devices are not universally hardened against adversarial input (especially when sysex is involved) so we don't believe this API is safe to expose in the casual and low-trust context of ordinary websites. We therefore only expose it in Firefox if the user has installed a site-specific add-on to explicitly extend the base web platform with high-trust capabilities ordinarily reserved for installed software.",
+    "mozPositionDetail": "This specification is a reasonable technical design for exposing MIDI devices to JavaScript, which has some demonstrated use-cases in the market. MIDI devices are not universally hardened against adversarial input (especially when sysex is involved) so we don't believe this API is safe to expose in the casual and low-trust context of ordinary websites. We therefore only expose it in Firefox if the user has deliberately installed a site-specific add-on to enable the capability.",
     "mozPositionIssue": 58,
     "org": "W3C",
     "title": "Web MIDI API (Add-On Gated)",

--- a/activities.json
+++ b/activities.json
@@ -1476,11 +1476,11 @@
     "id": "webmidi",
     "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/MIDIAccess",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=836897",
-    "mozPosition": "under consideration",
-    "mozPositionDetail": null,
+    "mozPosition": "positive",
+    "mozPositionDetail": "This specification is a reasonable technical design for exposing MIDI devices to JavaScript, which has some demonstrated use-cases in the market. MIDI devices are not universally hardened against adversarial input (especially when sysex is involved) so we don't believe this API is safe to expose in the casual and low-trust context of ordinary websites. We therefore only expose it in Firefox if the user has installed a site-specific add-on to explicitly extend the base web platform with high-trust capabilities ordinarily reserved for installed software.”,
     "mozPositionIssue": 58,
     "org": "W3C",
-    "title": "Web MIDI API",
+    "title": "Web MIDI API (Add-On Gated)",
     "url": "https://webaudio.github.io/web-midi-api/"
   },
   {


### PR DESCRIPTION
For an number of years, there's been strong disagreement between browser vendors over whether the Web should grow support for low-level access to various hardware peripherals.

We discuss this topic extensively in our recently-published [Web Vision](https://www.mozilla.org/en-US/about/webvision/). Because it's a long document and the relevant analysis is split across sections, I'm going to quote it inline here:

> The core promise of the Web is that people may browse anywhere on the Web without unintuitive harmful consequences.
>...
> This expectation is much stronger than with most native (i.e., downloadable rather than Web) software platforms. Traditionally, these platforms have not attempted to restrict the behavior of downloaded programs and instead required individuals to trust the author and install at their own risk. Newer platforms offer some limited technical protections, but struggle to convey the implications in a way that people [can understand](https://people.eecs.berkeley.edu/~daw/papers/anduser-soups12.pdf). As a consequence, such platforms largely lean on curated app stores and package signing to manage abuse. On the Web, no such mechanisms are needed because safety comes first: because the browser is designed to safely render any page, users can freely browse the Web without relying on someone curating the set of “safe” pages. This allows the Web to have very low barriers to entry and minimal central gatekeeping.
>
> Safety is a promise, and maintaining it engenders trust and confidence in the Web. Trust in turn enables casual browsing, empowering individuals with unprecedented freedom to explore, and eliminating the need for gatekeepers to decide what may or may not be part of the Web.
> ...
> Safety concerns also come into play whenever we consider adding new capabilities to the Web Platform. There are many advantages to publishing on the Web, but the Web also limits what sites can do. This has resulted in ongoing efforts to expand the variety of content that can be delivered via the browser by adding new capabilities, such as access to the camera or microphone for WebRTC interactions, running fast compiled code written in any language with WebAssembly, and more immersive apps with the Fullscreen API. For the most part, this is a good thing: people can access an ever-wider set of experiences with all the benefits that the Web brings. However, new capabilities can introduce risks which must be managed carefully.
>
> Ideally, new capabilities can be designed so that they can be safely exposed to any site without requesting the user’s permission. Often this takes some care and results in a feature which is somewhat different from the equivalent functionality available to native applications. For example, it is not safe to allow Web content to open up an arbitrary TCP socket to any server on the Internet because that capability could be used to bypass corporate firewalls. Instead, WebSockets and WebRTC both implement mechanisms which ensure that the website can only talk to servers which have consented to communicate with them. This allows us to make those APIs universally available without having to explain the risks to the user.
>
> However, other capabilities — like camera access — involve inherent risks which are difficult to sidestep. In these cases, we cannot safely expose the capability by default. In some circumstances, it may be appropriate to offer people the choice to enable it for a given site. We use the following criteria to evaluate whether that is the case:
> * Value: Does the capability deliver sufficient benefit to the user to warrant the risk?
> * Severity: What level of harm can occur if the capability is misused?
> * Consent: Can individuals make an informed decision about the risk?
> * Transparency: Is it clear how the capability is being used, and by whom?
> * Revocability: What happens if someone changes their mind?
>
> For camera access, the consequences of misuse are serious but they’re also easy to understand: the site can see whatever the camera is pointed at and users have the ability to cover or reorient their camera if they are concerned about covert usage by sites to which they have granted permission. Additionally, revoking camera access has clear implications and is easy to verify, while the value of teleconferencing on the Web is substantial. Combined with a variety of [technical mitigations](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Privacy_and_security), we concluded that it was appropriate to offer camera access on the Web.
>
> Permission prompts alone cannot make every capability safe, however, and we are wary of subjecting people to a barrage of inscrutable and high-stakes choices, along with the resulting [decision fatigue](https://en.wikipedia.org/wiki/Decision_fatigue). Some features require careful consideration of consequences, which is directly at odds with the goal of casual browsing. Moreover, individuals are often ill-equipped to understand the risks and consequences. In practice, [evidence suggests](https://cups.cs.cmu.edu/soups/2012/proceedings/a3_Felt.pdf) that many people just accept whatever prompts they’re offered — particularly as they become more common. If this [results in surprise and regret](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), individuals will lose trust in the Web.
>
> For example, we think the proposed [WebUSB API](https://wicg.github.io/webusb/) is not good for the Web. WebUSB enables low-level communication between a website and any device plugged into someone’s computer. Most USB devices are not hardened against adversarial input, and connecting them to untrusted sources could enable [credential theft](https://www.yubico.com/support/security-advisories/ysa-2018-02/), malware injection, surveillance, or even physical harm. These risks are opaque to most people, and the protocol operates quickly and silently without any standard indication of whether and how it is being used. And while WebUSB offers real benefits for certain specialized tasks like updating firmware, those tasks are generally not things most people do on a daily basis. For this reason we concluded that it was not safe to offer the WebUSB API. By contrast, higher-level APIs like [WebAuthn](https://webauthn.io/) allow for the use of USB tokens for specific applications we have determined to be safe.
>
> As a general principle, we are enthusiastic about bringing more content and applications to the Web. But certain applications may just not be suitable for the Web at large, and that’s OK. In some cases, we may be able to resolve this tension by allowing users to extend their browser to provide elevated capabilities to specific sites they trust.
> ...
> Add-ons have access to much more powerful capabilities than sites do, which makes them distinctly not casual. This necessitates some degree of gatekeeping and curation in order to keep people safe from malicious add-ons. We are exploring ways to reduce this friction, but ultimately need to exercise some degree of oversight to balance openness, agency, and safety for browser extensions.
>
> Add-ons can also provide a mechanism for extending the regular Web Platform with features which are too dangerous to provide by default. Because users must explicitly install add-ons and are reminded as part of the installation experience that add-ons have powerful privileges beyond those of ordinary Web pages, site-specific add-ons can allow users to provide elevated capabilities to sites they trust without compromising the casual interaction model that underpins the Web. We are [actively experimenting](https://bugzilla.mozilla.org/show_bug.cgi?id=1737161) with this approach in Firefox.

We've now experimented on a few different models, and tentatively settled on an approach which we believe appropriate balances the safety and ergonomics of the various constituents. The add-on is automatically synthesized when `requestMIDIAccess()` is invoked (and there is at least one active MIDI device available), so the site author doesn't need to go to the trouble of generating and serving an XPI. But the user experience is roughly the same as if they had, and we retain the same ability to remotely block identified bad actors. The consent flow looks like this:
 
<img width="418" alt="Screenshot 2022-11-10 at 4 13 57 PM" src="https://user-images.githubusercontent.com/377435/201232851-4aeca25e-5ce8-49e8-8774-bb40e35e0474.png">

Followed by:

<img width="436" alt="Screenshot 2022-11-10 at 4 14 10 PM" src="https://user-images.githubusercontent.com/377435/201232881-f7f70038-dc00-4224-a7f8-0f7eb3b18fc8.png">

With the "learn more" link opening [this](https://support.mozilla.org/en-US/kb/site-permission-addons).

This is quite different from our ordinary permission prompt UI in terms of metaphor, tone, and placement. If a malicious site can cajole a user through this flow, they have a multitude of attack vectors available to them irrespective of what we do with WebMIDI.

I'll conclude by noting that we handle sysex and non-sysex in roughly the same fashion, in contrast to Chrome which silently permits ordinary WebMIDI access without any consent whatsoever. Even setting aside the privacy implications of allowing arbitrary sites to enumerate rare peripherals, we maintain our position that this is unsafe to assume these device endpoints are hardened against adversarial input. Indeed, the world's most common MIDI device — the virtual one built into Windows — was [found to be vulnerable](https://bugs.chromium.org/p/chromium/issues/detail?id=499279) and had to be blocklisted in Chrome, which is not a positive indicator of the state of the long tail.

Closes #58.