### PR TITLE
Web Locks is in WebAppsWG as FPWD

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1492,9 +1492,9 @@
     "mozPosition": "positive",
     "mozPositionDetail": "The specification provides important web platform primitives for same-global and cross-global coordination and avoids requiring other APIs to grow their own transaction abstractions (ex: the Service Worker spec's Cache API).",
     "mozPositionIssue": 64,
-    "org": "Proposal",
+    "org": "W3C",
     "title": "Web Locks API",
-    "url": "https://wicg.github.io/web-locks/"
+    "url": "https://www.w3.org/TR/web-locks/"
   },
   {
     "ciuName": "midi",

--- a/activities.json
+++ b/activities.json
@@ -1494,7 +1494,7 @@
     "mozPositionIssue": 64,
     "org": "W3C",
     "title": "Web Locks API",
-    "url": "https://www.w3.org/TR/web-locks/"
+    "url": "https://w3c.github.io/web-locks/"
   },
   {
     "ciuName": "midi",


### PR DESCRIPTION
Web Locks API has been published as a FPWD by the Web Apps WG. New official standards track URL, and org W3C