### PR TITLE
Global Privacy Control (positive)

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -688,6 +688,18 @@
     "url": "https://wicg.github.io/get-installed-related-apps/spec"
   },
   {
+    "ciuName": null,
+    "description": "This spec defines a signal that conveys a person's request to websites and services to not sell or share their personal information with third parties.",
+    "id": "gpc",
+    "mozBugUrl": null,
+    "mozPosition": "positive",
+    "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations. This is a win for user privacy now that there are regulatory teeth coming in.",
+    "mozPositionIssue": 867,
+    "org": "W3C",
+    "title": "Global Privacy Control (GPC)",
+    "url": "https://privacycg.github.io/gpc-spec/"
+  },
+  {
     "ciuName": "imports",
     "description": "HTML Imports are a way to include and reuse HTML documents in other HTML documents.",
     "id": "html-imports",

--- a/activities.json
+++ b/activities.json
@@ -691,7 +691,7 @@
     "ciuName": null,
     "description": "This spec defines a signal that conveys a person's request to websites and services to not sell or share their personal information with third parties.",
     "id": "gpc",
-    "mozBugUrl": null,
+    "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1848951",
     "mozPosition": "positive",
     "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations. This is a win for user privacy now that there are regulatory teeth coming in.",
     "mozPositionIssue": 867,

--- a/activities.json
+++ b/activities.json
@@ -691,7 +691,7 @@
     "ciuName": null,
     "description": "This spec defines a signal that conveys a person's request to websites and services to not sell or share their personal information with third parties.",
     "id": "gpc",
-    "mdnUrl": ["https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-GPC", "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl"],
+    "mdnUrl": ["https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl"],
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1848951",
     "mozPosition": "positive",
     "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations.",

--- a/activities.json
+++ b/activities.json
@@ -691,6 +691,7 @@
     "ciuName": null,
     "description": "This spec defines a signal that conveys a person's request to websites and services to not sell or share their personal information with third parties.",
     "id": "gpc",
+    "mdnUrl": ["https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-GPC", "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl"],
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1848951",
     "mozPosition": "positive",
     "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations. This is a win for user privacy now that there are regulatory teeth coming in.",

--- a/activities.json
+++ b/activities.json
@@ -694,7 +694,7 @@
     "mdnUrl": ["https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-GPC", "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl"],
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1848951",
     "mozPosition": "positive",
-    "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations. This is a win for user privacy now that there are regulatory teeth coming in.",
+    "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations.",
     "mozPositionIssue": 867,
     "org": "W3C",
     "title": "Global Privacy Control (GPC)",

--- a/activities.json
+++ b/activities.json
@@ -696,7 +696,7 @@
     "mozPosition": "positive",
     "mozPositionDetail": "This signal defined in this specification provides users with a way to opt-out of the disclosure of their information to third parties once per profile in a way that is legally enforced in some jurisdictions, and is being considered in future regulations.",
     "mozPositionIssue": 867,
-    "org": "W3C",
+    "org": "Proposal",
     "title": "Global Privacy Control (GPC)",
     "url": "https://privacycg.github.io/gpc-spec/"
   },


### PR DESCRIPTION
There are two ciu links that are relevant... we could just pick one, but I left it null.

This should probably have @martinthomson's eyes, particularly on the mozPositionDetail.