### PR TITLE
s/webrtc-insertable-streams/webrtc-encoded-transform/ fixes broken link

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1848,16 +1848,16 @@
   },
   {
     "ciuName": null,
-    "description": "This API defines an API surface for manipulating the bits on MediaStreamTracks being sent via an RTCPeerConnection.",
-    "id": "webrtc-insertable-streams",
+    "description": "This API defines an API surface for manipulating the encoded bits of MediaStreamTracks being sent via an RTCPeerConnection.",
+    "id": "webrtc-encoded-transform",
     "mdnUrl": null,
     "mozBugUrl": null,
     "mozPosition": "positive",
     "mozPositionDetail": "This approach provides sites a way to offer a form of end-to-end protection for media, especially in those very common cases where media for group sessions is managed by a central service. The proposed API, together with the SFrame proposal, provides sites the ability to limit the information that is exposed to the central service. Mozilla would prefer to include better key management than this approach proposes, perhaps using <a href=\"https://datatracker.ietf.org/doc/html/draft-ietf-mls-architecture\">MLS</a>, which might guarantee certain security and privacy gains for users. However, we recognize that this is not yet feasible and this API can provide security and privacy gains if carefully applied by sites.",
     "mozPositionIssue": 330,
     "org": "W3C",
-    "title": "WebRTC Insertable Media using Streams",
-    "url": "https://w3c.github.io/webrtc-insertable-streams/"
+    "title": "WebRTC Encoded Transform",
+    "url": "https://w3c.github.io/webrtc-encoded-transform/"
   },
   {
     "ciuName": "",


### PR DESCRIPTION
The old link was broken (and forwarding appears to have stopped).

The spec is now at https://www.w3.org/TR/webrtc-encoded-transform/ not to be confused with https://www.w3.org/TR/mediacapture-transform/ (tiny edit of description to clarify this is not the latter)