### PR TITLE
Positive: Long Animation Frame API

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -924,6 +924,18 @@
   },
   {
     "ciuName": null,
+    "description": "This specification defines APIs for reporting information for frames that take a long time to render.",
+    "id": "long-animation-frame-api",
+    "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1734997",
+    "mozPosition": "positive",
+    "mozPositionDetail": "This feature allows web developers to measure frame congestion and jank, and has a correlation with how user perceive this type of congestion. Web developers can use this API to improve the perceived performance of their pages.",
+    "mozPositionIssue": 929,
+    "org": "Proposal",
+    "title": "Long Animation Frame API",
+    "url": "https://w3c.github.io/longtasks/#sec-loaf-timing"
+  },
+  {
+    "ciuName": null,
     "description": "This describes APIs for TCP and UDP communication with arbitrary hosts",
     "id": "low-level-sockets",
     "mdnUrl": null,


### PR DESCRIPTION
closes: #929


Long Animation API is an revamp of Long Task API and they are in the same spec at the moment. I've filed https://github.com/w3c/longtasks/issues/132 to consider separating Long Animation Frame out.  