### PR TITLE
Add Webkit s-p link template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,7 +8,8 @@
 * Proposal author(s) (`@`-mention GitHub accounts): 
 * Caniuse.com URL (optional): 
 * Bugzilla URL (optional): 
-* Mozillians who can provide input (optional): 
+* Mozillians who can provide input (optional):
+* WebKit standards-position: 
 
 ### Other information
 


### PR DESCRIPTION
Fixes #1011

GitHub warns that ISSUE_TEMPLATE.md is old and should migrate to new one 👀 but that can happen separately.