### PR TITLE
Map mozilla positions to web-features IDs

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -318,7 +318,7 @@
     "org": "W3C",
     "title": "CSS Relational Pseudo-Class (:has())",
     "url": "https://drafts.csswg.org/selectors/#relational",
-    "webFeaturesID": "has"
+    "webFeaturesId": "has"
   },
   {
     "ciuName": "css-cascade-scope",
@@ -331,7 +331,7 @@
     "org": "W3C",
     "title": "CSS Scoped Styles",
     "url": "https://drafts.csswg.org/css-cascade-6/#scoped-styles",
-    "webFeaturesID": "scope"
+    "webFeaturesId": "scope"
   },
   {
     "ciuName": null,
@@ -369,7 +369,7 @@
     "org": "W3C",
     "title": "CSS View Transitions Module Level 1",
     "url": "https://drafts.csswg.org/css-view-transitions/",
-    "webFeaturesID": "view-transitions"
+    "webFeaturesId": "view-transitions"
   },
   {
     "ciuName": "mdn-css_properties_overflow_clip",
@@ -420,7 +420,7 @@
     "org": "W3C",
     "title": "Clipboard API and events",
     "url": "https://w3c.github.io/clipboard-apis/",
-    "webFeaturesID": "async-clipboard"
+    "webFeaturesId": "async-clipboard"
   },
   {
     "ciuName": null,
@@ -829,7 +829,7 @@
     "org": "Proposal",
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
     "url": "https://wicg.github.io/video-rvfc",
-    "webFeaturesID": "request-video-frame-callback"
+    "webFeaturesId": "request-video-frame-callback"
   },
   {
     "ciuName": null,
@@ -867,7 +867,7 @@
     "org": "Proposal",
     "title": "Idle Detection API",
     "url": "https://wicg.github.io/idle-detection/",
-    "webFeaturesID": "idle-detection"
+    "webFeaturesId": "idle-detection"
   },
   {
     "ciuName": null,
@@ -928,7 +928,7 @@
     "org": "W3C",
     "title": "IntersectionObserver V2",
     "url": "https://github.com/w3c/IntersectionObserver/pull/523",
-    "webFeaturesID": "intersection-observer-v2"
+    "webFeaturesId": "intersection-observer-v2"
   },
   {
     "ciuName": null,
@@ -955,7 +955,7 @@
     "org": "Other",
     "title": "JPEG-XL",
     "url": "https://www.iso.org/standard/77977.html?browse=tc",
-    "webFeaturesID": "jpegxl"
+    "webFeaturesId": "jpegxl"
   },
   {
     "ciuName": "mdn-api_keyboardlayoutmap",
@@ -1068,7 +1068,7 @@
     "org": "W3C",
     "title": "Managed Media Source",
     "url": "https://github.com/w3c/media-source/issues/320",
-    "webFeaturesID": "managed-media-source"
+    "webFeaturesId": "managed-media-source"
   },
   {
     "ciuName": null,
@@ -1095,7 +1095,7 @@
     "org": "W3C",
     "title": "Media Session Standard",
     "url": "https://w3c.github.io/mediasession/",
-    "webFeaturesID": "media-session"
+    "webFeaturesId": "media-session"
   },
   {
     "ciuName": "mdn-api_mediastreamtrack_contenthint",
@@ -1135,7 +1135,7 @@
     "org": "WHATWG",
     "title": "Navigation API",
     "url": "https://github.com/whatwg/html/pull/8502",
-    "webFeaturesID": "navigation"
+    "webFeaturesId": "navigation"
   },
   {
     "ciuName": null,
@@ -1271,7 +1271,7 @@
     "org": "Proposal",
     "title": "Picture-in-Picture",
     "url": "https://wicg.github.io/picture-in-picture/",
-    "webFeaturesID": "document-picture-in-picture"
+    "webFeaturesId": "document-picture-in-picture"
   },
   {
     "ciuName": "portals",
@@ -1296,7 +1296,7 @@
     "org": "Proposal",
     "title": "Prioritized Task Scheduling",
     "url": "https://wicg.github.io/scheduling-apis/",
-    "webFeaturesID": "scheduler"
+    "webFeaturesId": "scheduler"
   },
   {
     "ciuName": null,
@@ -1385,7 +1385,7 @@
     "org": "W3C",
     "title": "Relative color syntax (CSS Color Module Level 5)",
     "url": "https://drafts.csswg.org/css-color-5/#relative-colors",
-    "webFeaturesID": "relative-color"
+    "webFeaturesId": "relative-color"
   },
   {
     "ciuName": null,
@@ -1472,7 +1472,7 @@
     "org": "W3C",
     "title": "Scroll-driven Animations",
     "url": "https://drafts.csswg.org/scroll-animations-1/",
-    "webFeaturesID": "scroll-driven-animations"
+    "webFeaturesId": "scroll-driven-animations"
   },
   {
     "ciuName": null,
@@ -1584,7 +1584,7 @@
     "org": "Proposal",
     "title": "Storage Buckets API",
     "url": "https://wicg.github.io/storage-buckets/",
-    "webFeaturesID": "storage-buckets"
+    "webFeaturesId": "storage-buckets"
   },
   {
     "ciuName": "streams",
@@ -1648,7 +1648,7 @@
     "org": "Proposal",
     "title": "Text Fragments",
     "url": "https://wicg.github.io/scroll-to-text-fragment/",
-    "webFeaturesID": "scroll-to-text-fragment"
+    "webFeaturesId": "scroll-to-text-fragment"
   },
   {
     "ciuName": null,
@@ -1723,7 +1723,7 @@
     "org": "W3C",
     "title": "Trusted Types",
     "url": "https://w3c.github.io/trusted-types/dist/spec/",
-    "webFeaturesID": "trusted-types"
+    "webFeaturesId": "trusted-types"
   },
   {
     "ciuName": "mdn-api_urlpattern",
@@ -1813,7 +1813,7 @@
     "org": "Proposal",
     "title": "Web Bluetooth",
     "url": "https://webbluetoothcg.github.io/web-bluetooth/",
-    "webFeaturesID": "web-bluetooth"
+    "webFeaturesId": "web-bluetooth"
   },
   {
     "ciuName": null,
@@ -1838,7 +1838,7 @@
     "org": "Proposal",
     "title": "Web Codecs",
     "url": "https://github.com/WICG/web-codecs",
-    "webFeaturesID": "webcodecs"
+    "webFeaturesId": "webcodecs"
   },
   {
     "ciuName": "webgpu",
@@ -1877,7 +1877,7 @@
     "org": "W3C",
     "title": "Web MIDI API (Add-On Gated)",
     "url": "https://webaudio.github.io/web-midi-api/",
-    "webFeaturesID": "web-midi"
+    "webFeaturesId": "web-midi"
   },
   {
     "ciuName": "webnfc",
@@ -1890,7 +1890,7 @@
     "org": "Proposal",
     "title": "Web NFC",
     "url": "https://w3c.github.io/web-nfc/",
-    "webFeaturesID": "web-nfc"
+    "webFeaturesId": "web-nfc"
   },
   {
     "ciuName": "web-share",
@@ -1993,7 +1993,7 @@
     "org": "Proposal",
     "title": "WebHID API",
     "url": "https://wicg.github.io/webhid/",
-    "webFeaturesID": "webhid"
+    "webFeaturesId": "webhid"
   },
   {
     "ciuName": null,
@@ -2032,7 +2032,7 @@
     "org": "Proposal",
     "title": "WebUSB API",
     "url": "https://wicg.github.io/webusb/",
-    "webFeaturesID": "webusb"
+    "webFeaturesId": "webusb"
   },
   {
     "ciuName": "webxr",

--- a/activities.json
+++ b/activities.json
@@ -317,7 +317,8 @@
     "mozPositionIssue": 528,
     "org": "W3C",
     "title": "CSS Relational Pseudo-Class (:has())",
-    "url": "https://drafts.csswg.org/selectors/#relational"
+    "url": "https://drafts.csswg.org/selectors/#relational",
+    "webFeaturesID": "has"
   },
   {
     "ciuName": "css-cascade-scope",
@@ -329,7 +330,8 @@
     "mozPositionIssue": 472,
     "org": "W3C",
     "title": "CSS Scoped Styles",
-    "url": "https://drafts.csswg.org/css-cascade-6/#scoped-styles"
+    "url": "https://drafts.csswg.org/css-cascade-6/#scoped-styles",
+    "webFeaturesID": "scope"
   },
   {
     "ciuName": null,
@@ -366,7 +368,8 @@
     "mozPositionIssue": 677,
     "org": "W3C",
     "title": "CSS View Transitions Module Level 1",
-    "url": "https://drafts.csswg.org/css-view-transitions/"
+    "url": "https://drafts.csswg.org/css-view-transitions/",
+    "webFeaturesID": "view-transitions"
   },
   {
     "ciuName": "mdn-css_properties_overflow_clip",
@@ -416,7 +419,8 @@
     "mozPositionIssue": 89,
     "org": "W3C",
     "title": "Clipboard API and events",
-    "url": "https://w3c.github.io/clipboard-apis/"
+    "url": "https://w3c.github.io/clipboard-apis/",
+    "webFeaturesID": "async-clipboard"
   },
   {
     "ciuName": null,
@@ -824,7 +828,8 @@
     "mozPositionIssue": 250,
     "org": "Proposal",
     "title": "HTMLVideoElement.requestVideoFrameCallback()",
-    "url": "https://wicg.github.io/video-rvfc"
+    "url": "https://wicg.github.io/video-rvfc",
+    "webFeaturesID": "request-video-frame-callback"
   },
   {
     "ciuName": null,
@@ -861,7 +866,8 @@
     "mozPositionIssue": 453,
     "org": "Proposal",
     "title": "Idle Detection API",
-    "url": "https://wicg.github.io/idle-detection/"
+    "url": "https://wicg.github.io/idle-detection/",
+    "webFeaturesID": "idle-detection"
   },
   {
     "ciuName": null,
@@ -921,7 +927,8 @@
     "mozPositionIssue": 109,
     "org": "W3C",
     "title": "IntersectionObserver V2",
-    "url": "https://github.com/w3c/IntersectionObserver/pull/523"
+    "url": "https://github.com/w3c/IntersectionObserver/pull/523",
+    "webFeaturesID": "intersection-observer-v2"
   },
   {
     "ciuName": null,
@@ -947,7 +954,8 @@
     "mozPositionIssue": 522,
     "org": "Other",
     "title": "JPEG-XL",
-    "url": "https://www.iso.org/standard/77977.html?browse=tc"
+    "url": "https://www.iso.org/standard/77977.html?browse=tc",
+    "webFeaturesID": "jpegxl"
   },
   {
     "ciuName": "mdn-api_keyboardlayoutmap",
@@ -1059,7 +1067,8 @@
     "mozPositionIssue": 845,
     "org": "W3C",
     "title": "Managed Media Source",
-    "url": "https://github.com/w3c/media-source/issues/320"
+    "url": "https://github.com/w3c/media-source/issues/320",
+    "webFeaturesID": "managed-media-source"
   },
   {
     "ciuName": null,
@@ -1085,7 +1094,8 @@
     "mozPositionIssue": 28,
     "org": "W3C",
     "title": "Media Session Standard",
-    "url": "https://w3c.github.io/mediasession/"
+    "url": "https://w3c.github.io/mediasession/",
+    "webFeaturesID": "media-session"
   },
   {
     "ciuName": "mdn-api_mediastreamtrack_contenthint",
@@ -1124,7 +1134,8 @@
     "mozPositionIssue": 543,
     "org": "WHATWG",
     "title": "Navigation API",
-    "url": "https://github.com/whatwg/html/pull/8502"
+    "url": "https://github.com/whatwg/html/pull/8502",
+    "webFeaturesID": "navigation"
   },
   {
     "ciuName": null,
@@ -1259,7 +1270,8 @@
     "mozPositionIssue": 72,
     "org": "Proposal",
     "title": "Picture-in-Picture",
-    "url": "https://wicg.github.io/picture-in-picture/"
+    "url": "https://wicg.github.io/picture-in-picture/",
+    "webFeaturesID": "document-picture-in-picture"
   },
   {
     "ciuName": "portals",
@@ -1283,7 +1295,8 @@
     "mozPositionIssue": 546,
     "org": "Proposal",
     "title": "Prioritized Task Scheduling",
-    "url": "https://wicg.github.io/scheduling-apis/"
+    "url": "https://wicg.github.io/scheduling-apis/",
+    "webFeaturesID": "scheduler"
   },
   {
     "ciuName": null,
@@ -1371,7 +1384,8 @@
     "mozPositionIssue": 841,
     "org": "W3C",
     "title": "Relative color syntax (CSS Color Module Level 5)",
-    "url": "https://drafts.csswg.org/css-color-5/#relative-colors"
+    "url": "https://drafts.csswg.org/css-color-5/#relative-colors",
+    "webFeaturesID": "relative-color"
   },
   {
     "ciuName": null,
@@ -1457,7 +1471,8 @@
     "mozPositionIssue": 347,
     "org": "W3C",
     "title": "Scroll-driven Animations",
-    "url": "https://drafts.csswg.org/scroll-animations-1/"
+    "url": "https://drafts.csswg.org/scroll-animations-1/",
+    "webFeaturesID": "scroll-driven-animations"
   },
   {
     "ciuName": null,
@@ -1568,7 +1583,8 @@
     "mozPositionIssue": 475,
     "org": "Proposal",
     "title": "Storage Buckets API",
-    "url": "https://wicg.github.io/storage-buckets/"
+    "url": "https://wicg.github.io/storage-buckets/",
+    "webFeaturesID": "storage-buckets"
   },
   {
     "ciuName": "streams",
@@ -1631,7 +1647,8 @@
     "mozPositionIssue": 194,
     "org": "Proposal",
     "title": "Text Fragments",
-    "url": "https://wicg.github.io/scroll-to-text-fragment/"
+    "url": "https://wicg.github.io/scroll-to-text-fragment/",
+    "webFeaturesID": "scroll-to-text-fragment"
   },
   {
     "ciuName": null,
@@ -1705,7 +1722,8 @@
     "mozPositionIssue": 20,
     "org": "W3C",
     "title": "Trusted Types",
-    "url": "https://w3c.github.io/trusted-types/dist/spec/"
+    "url": "https://w3c.github.io/trusted-types/dist/spec/",
+    "webFeaturesID": "trusted-types"
   },
   {
     "ciuName": "mdn-api_urlpattern",
@@ -1794,7 +1812,8 @@
     "mozPositionIssue": 95,
     "org": "Proposal",
     "title": "Web Bluetooth",
-    "url": "https://webbluetoothcg.github.io/web-bluetooth/"
+    "url": "https://webbluetoothcg.github.io/web-bluetooth/",
+    "webFeaturesID": "web-bluetooth"
   },
   {
     "ciuName": null,
@@ -1818,7 +1837,8 @@
     "mozPositionIssue": 209,
     "org": "Proposal",
     "title": "Web Codecs",
-    "url": "https://github.com/WICG/web-codecs"
+    "url": "https://github.com/WICG/web-codecs",
+    "webFeaturesID": "webcodecs"
   },
   {
     "ciuName": "webgpu",
@@ -1856,7 +1876,8 @@
     "mozPositionIssue": 58,
     "org": "W3C",
     "title": "Web MIDI API (Add-On Gated)",
-    "url": "https://webaudio.github.io/web-midi-api/"
+    "url": "https://webaudio.github.io/web-midi-api/",
+    "webFeaturesID": "web-midi"
   },
   {
     "ciuName": "webnfc",
@@ -1868,7 +1889,8 @@
     "mozPositionIssue": 238,
     "org": "Proposal",
     "title": "Web NFC",
-    "url": "https://w3c.github.io/web-nfc/"
+    "url": "https://w3c.github.io/web-nfc/",
+    "webFeaturesID": "web-nfc"
   },
   {
     "ciuName": "web-share",
@@ -1970,7 +1992,8 @@
     "mozPositionIssue": 459,
     "org": "Proposal",
     "title": "WebHID API",
-    "url": "https://wicg.github.io/webhid/"
+    "url": "https://wicg.github.io/webhid/",
+    "webFeaturesID": "webhid"
   },
   {
     "ciuName": null,
@@ -2008,7 +2031,8 @@
     "mozPositionIssue": 100,
     "org": "Proposal",
     "title": "WebUSB API",
-    "url": "https://wicg.github.io/webusb/"
+    "url": "https://wicg.github.io/webusb/",
+    "webFeaturesID": "webusb"
   },
   {
     "ciuName": "webxr",


### PR DESCRIPTION
The [web-features repository](https://github.com/web-platform-dx/web-features) maintains a growing list of web platform features. This list acts as a hub for various web data such as browser-compat-data, Can I Use, specs, WPT, Chrome's usage counters, etc.

The most useful thing the web-features repo offers right now is a summary of browser support and a Baseline status per feature. The Baseline status, in particular, is used on the MDN Web Docs and Can I Use websites.
Other websites such as webstatus.dev use a bunch of information from web-features.

The [W3C WebDX CG](https://www.w3.org/community/webdx/) (which currently maintains the repo) [recently discussed](https://github.com/web-platform-dx/web-features/issues/186) mapping web-features entries to browser standard positions too.

This PR is a proposal for the first step towards achieving this. It adds IDs of features in the web-features repo to individual entries here. This is done by adding an optional `webFeaturesID` property to entries in `activities.json`. This property is a string which value matches filenames in https://github.com/web-platform-dx/web-features/tree/main/features (without the file extension).

If you agree with this approach, this will help us link Mozilla positions with a lot of other data about web platform features around various web properties.

I plan on proposing a similar PR for https://webkit.org/standards-positions/

cc @jgraham who we discussed this with.