### PR TITLE
Firefox will consider a Rust implementation of JPEG-XL

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -955,7 +955,7 @@
     "mdnUrl": null,
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1539075",
     "mozPosition": "neutral",
-    "mozPositionDetail": "JPEG-XL includes features and performance that might differentiate it from other formats, but the benefits it provides are not significant enough on their own to justify the cost of adding another C++ image decoder to Firefox. A memory-safe decoder would reduce these costs considerably, and we are open to shipping one that meets our requirements.",
+    "mozPositionDetail": "JPEG-XL includes features and performance that might differentiate it from other formats, but the benefits it provides are not significant enough on their own to justify the cost of adding another C++ image decoder to browsers. A memory-safe decoder would reduce these costs considerably, and we are open to shipping one that meets our requirements.",
     "mozPositionIssue": 522,
     "org": "Other",
     "title": "JPEG-XL",

--- a/activities.json
+++ b/activities.json
@@ -955,7 +955,7 @@
     "mdnUrl": null,
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1539075",
     "mozPosition": "neutral",
-    "mozPositionDetail": "JPEG-XL includes features and performance that might differentiate it from other formats, but the benefits it provides are not significant enough on their own to justify the cost of adding another raster image format to the Web.",
+    "mozPositionDetail": "JPEG-XL includes features and performance that might differentiate it from other formats, but the benefits it provides are not significant enough on their own to justify the cost of adding another C++ image decoder to Firefox. A memory-safe decoder would reduce these costs considerably, and we are open to shipping one that meets our requirements.",
     "mozPositionIssue": 522,
     "org": "Other",
     "title": "JPEG-XL",


### PR DESCRIPTION
Over the past few months, we’ve had some productive conversations with the JPEG-XL team at Google Research around the future of the format in Firefox. Our primary concern has long been the increased attack surface of the reference decoder (currently behind a pref in Firefox Nightly), which weighs in at more than 100,000 lines of multithreaded C++. To address this concern, the team at Google has agreed to apply their subject matter expertise to build a safe, performant, compact, and compatible JPEG-XL decoder in Rust, and integrate this decoder into Firefox. If they successfully contribute an implementation that satisfies these properties and meets our normal production requirements, we would ship it.

Time will tell whether the format succeeds in becoming a universal JPEG replacement in the way some folks hope. In the event that it does, it would be unfortunate to potentially introduce memory safety vulnerabilities across the myriad of applications that would eventually need to support it. A safe, fast, and battle-tested Rust decoder from the original team could make that scenario much less likely, and so we’re using our leverage to encourage progress on this front.

Previous discussion in #522.