### PR TITLE
Add a link to issue WICG/cookie-store #241 about the Cookie-Store API subset

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -496,7 +496,7 @@
     "id": "cookie-store",
     "mozBugUrl": "https://bugzilla.mozilla.org/show_bug.cgi?id=1475599",
     "mozPosition": "defer",
-    "mozPositionDetail": "This API provides better access to cookies. However, the improvements also expand access to cookie metadata and the interactions with privacy features like the Storage Access API are unclear. Work on improving cookie interoperability, which is ongoing, might be needed before an assessment can be made.",
+    "mozPositionDetail": "This API provides better access to cookies. However, the improvements also expand access to cookie metadata and the interactions with privacy features like the Storage Access API are unclear. Work on improving cookie interoperability, which is ongoing, might be needed before an assessment can be made. See <a href=\"https://github.com/WICG/cookie-store/issues/241\">WICG/cookie-store issue #241</a>",
     "mozPositionIssue": 94,
     "org": "Proposal",
     "title": "Cookie Store API",


### PR DESCRIPTION
See https://github.com/mozilla/standards-positions/pull/1047#pullrequestreview-2146610462

This PR adds a link to the issue WICG/cookie-store #241 about the Cookie-Store API subset