### PR TITLE
Fix deploy workflow to fetch and rebase

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch full history to support rebasing
 
       - name: Set up SSH for Git (deploy key)
         run: |
@@ -33,22 +35,42 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Fetch GitHub data
+      - name: Generate Merged Data
         run: |
           python3 gh-data.py
-
-      - name: Merge data sources
-        run: |
           python3 merge-data.py
 
-      - name: Commit and Push Changes to `gh-pages`
+      - name: Switch to `gh-pages` and Preserve Changes
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b gh-pages
+
+          # Stash changes to preserve them
+          git stash --include-untracked
+
+          # Fetch and switch to `gh-pages`
+          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+          git checkout gh-pages
+
+          # Rebase `gh-pages` onto `main` to ensure a linear history
+          git rebase main
+
+          # Apply stashed changes
+          git stash pop || echo "No changes to apply."
+
+      - name: Commit and Push Updates
+        run: |
+          # Add changes
           git add -f merged-data.json
           git add .
-          # If there are no changes, no commit gets created, and nothing is pushed
-          git commit -m "Update GitHub Pages with latest data"
+
+          # Commit changes if there are any
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update GitHub Pages with latest data"
+          fi
+
+          # Push changes back to `gh-pages`
           git remote set-url origin git@github.com:${{ github.repository }}.git
           git push origin gh-pages


### PR DESCRIPTION
The workflow fails to push changes to gh-pages because it has commits that are not in the local branch.