### PR TITLE
Fix deploy workflow (take 4)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -65,7 +65,11 @@ jobs:
           git add -f merged-data.json
 
           # Commit changes if there are any
-          git commit -m "Update GitHub Pages with latest data"
+          if ! git diff --cached --quiet; then
+            git commit -m "Update GitHub Pages with latest data"
+          else
+            echo "No changes to commit."
+          fi
 
           # Push changes back to `gh-pages`
           git remote set-url origin git@github.com:${{ github.repository }}.git


### PR DESCRIPTION
If there is nothing to commit for merged-data.json, git commit exits with a non-zero code.