### PR TITLE
CookieStore for ServiceWorkers (bug 1947894)

### DIFF
--- a/activities.yml
+++ b/activities.yml
@@ -493,7 +493,7 @@ Cookie Store API:
   issue: 94
   position: positive
   rationale: |
-    This API provides better access to cookies. We are positive for a subset of this API which only exposes the same information available through document.cookie. At this time we're not ready to expose ServiceWorkerRegistration.cookies or implement the CookieStoreManager as proposed; we will discuss this along with the subset proposal in the appropriate standards group. See [WICG/cookie-store issue #241](https://github.com/WICG/cookie-store/issues/241).
+    This API provides better access to cookies. We are positive for a subset of this API which only exposes the same information available through document.cookie. See [WICG/cookie-store issue #241](https://github.com/WICG/cookie-store/issues/241).
   url: https://wicg.github.io/cookie-store/
   venues:
   - Proposal


### PR DESCRIPTION
For web-compat reasons,  we decided to implement CookieStoreManager. This commit updates our standard position about CookieStore to cover this ServiceWorker part.