### PR TITLE
update CONTRIBUTING to link to new API_ISSUE_TEMPLATE.md

### DIFF
--- a/API_ISSUE_TEMPLATE.md
+++ b/API_ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+### Specification title
+
+_No response_ <!-- replace _No response_ with your answer, re-use this as the issue title -->
+
+### Specification or proposal URL (if available)
+
+_No response_  <!-- replace _No response_ with the spec's https://... -->
+
+### Explainer URL (if available)
+
+_No response_ <!-- replace _No response_ with the explainer's https://... -->
+
+### Proposal author(s)
+
+_No response_ <!-- replace _No response_ with your @handle -->
+
+### MDN URL
+
+_No response_ <!-- replace _No response_ with feature's https://developer.mozilla.org/... -->
+
+### Caniuse.com URL
+
+_No response_ <!-- replace _No response_ with feature's https://caniuse.com/... -->
+
+### Bugzilla URL
+
+_No response_ <!-- replace _No response_ with feature's https://bugzil.la/NNNNNNN -->
+
+### Mozillians who can provide input
+
+_No response_ <!-- replace _No response_ with specific Mozilla @handles like @zcorpan, @emilio etc. -->
+
+### WebKit standards-position
+
+_No response_ <!-- replace _No response_ with the spec's https://github.com/WebKit/standards-positions/issues/NNN -->
+
+### Other information
+
+_No response_ <!-- replace _No response_ with your answer; delete all HTML comments -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If there is a public, Web-related specification that you think Mozilla might be 
 please
 [open a new issue](https://github.com/mozilla/standards-positions/issues/new),
 filling out the auto-included template appropriately. (If posting via GitHub API, please copy the
-[template](https://github.com/mozilla/standards-positions/blob/main/ISSUE_TEMPLATE.md)
+[template](https://github.com/mozilla/standards-positions/blob/main/API_ISSUE_TEMPLATE.md)
 and fill it out).
 
 Normally, the appropriate granularity for an issue is a distinct web platform feature. This could


### PR DESCRIPTION
restore an API-only template for use with the GitHub API since the old ISSUE_TEMPLATE.md was deleted