### PR TITLE
Replace deprecated substr() with substring() in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@
        }
 
        if (location.hash) {
-         expandDetailsForTarget(location.hash.substr(1));
+         expandDetailsForTarget(location.hash.substring(1));
        }
        onhashchange = e => {
          expandDetailsForTarget(e.newURL.split('#')[1]);


### PR DESCRIPTION
## Summary
`String.prototype.substr()` is deprecated (Annex B of ECMA-262) and may be removed in future browser versions. This replaces the single usage in `index.html` with `substring()`, which is functionally identical for this use case (stripping the leading `#` from `location.hash`).

## Test plan
- [ ] Open `index.html` locally and verify hash-based deep linking still works (e.g., appending `#some-spec` to the URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)