### PR TITLE
Fix incorrect comments in pre-commit script

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -2,9 +2,9 @@
 # This is a pre-commit hook that validates code formatting.
 #
 # Install this by running the script with an argument of "install",
-# which adds a symlink at .git/hooks/precommit; or run the equivalent:
+# which adds a symlink at .git/hooks/pre-commit; or run the equivalent:
 #
-# $ ln -s ../../hooks/pre-commit .git/pre-commit
+# $ ln -s ../../pre-commit .git/hooks/pre-commit
 
 root="$(git rev-parse --show-toplevel 2>/dev/null)"
 venv="$root/venv"


### PR DESCRIPTION
## Summary
The comments in the `pre-commit` hook script (lines 5-7) contain two errors:

1. **Line 5**: Says `.git/hooks/precommit` (missing hyphen) — should be `.git/hooks/pre-commit`
2. **Line 7**: Manual install example has wrong source and target paths:
   - Was: `ln -s ../../hooks/pre-commit .git/pre-commit`
   - Should be: `ln -s ../../pre-commit .git/hooks/pre-commit`

The actual installation code (lines 20-25) is correct — only the instructional comments were wrong, which could confuse someone trying to manually install the hook.

## Test plan
- [ ] Verify the corrected comment paths match the actual code behavior at lines 20-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)