### PR TITLE
Fix variable reference bug in gh-data.py

### DIFF
--- a/gh-data.py
+++ b/gh-data.py
@@ -150,7 +150,7 @@ def process_body(issue):
                 continue
             if expect_response:
                 value = line.strip()
-                if key in ("url", "explainer", "mdn", "caniuse", "bug", "webkit"):
+                if expect_response in ("url", "explainer", "mdn", "caniuse", "bug", "webkit"):
                     value = get_url(value)
                 if value and value != "_No response_" and value.lower() != "n/a":
                     body[expect_response] = value


### PR DESCRIPTION
## Summary
Fixes a variable reference bug in `gh-data.py` in the `process_body()` function's YAML template processing path (lines 136-157).

**The bug:** At line 153, `key` is used instead of `expect_response` in the condition `if key in ("url", "explainer", "mdn", "caniuse", "bug", "webkit"):`. After the inner `for` loop at line 142 completes without a match, `key` always holds the last value from `yaml_mapping.items()` — which is `"webkit"`.

**Why it works by accident:** Since `"webkit"` is in the checked tuple, `get_url()` is always called. This is currently correct because all fields in `yaml_mapping` should have `get_url()` applied. But if a new field that should NOT have `get_url()` applied were added to `yaml_mapping`, it would be incorrectly processed.

**The fix:** Change `key` to `expect_response` at line 153, which correctly references the field name that was matched in the preceding loop.

## Test plan
- [ ] Run `python gh-data.py` (with `GITHUB_TOKEN` set) and verify output is unchanged
- [ ] Code review: verify `expect_response` is the semantically correct variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)